### PR TITLE
P1-2: JSONスキーマ定義・パーサ実装

### DIFF
--- a/.claude/commands/fix-github-issue.md
+++ b/.claude/commands/fix-github-issue.md
@@ -6,6 +6,7 @@ GitHub issueを分析して実行してください: issue番号 $ARGUMENTS
 2. 問題の理解
 3. 関連ファイルの検索
 4. コードの実装
-5. コミット(developブランチに直接コミットしないこと。feature/\*ブランチにコミットすること。)
-6. developブランチへのプルリクエスト作成。プルリクエストには対応したissueについて「Closes #issue no」を書く。
-7. サブエージェントcode-reviewer-jpにより修正したコードについてレビューを実施し、結果はプルリクエストのレビューコメントとして書く。
+5. src/のファイルを修正した場合、修正した内容についてのテストコードを実装する。また、.github/workflows/ci.ymlで実行しているcargo fmt,cargo clippy,cargo testを実行して、エラーがあれば修正する。
+6. コミット(developブランチに直接コミットしないこと。feature/\*ブランチにコミットすること。)
+7. developブランチへのプルリクエスト作成。プルリクエストには対応したissueについて「Closes #issue no」を書く。
+8. サブエージェントcode-reviewer-jpにより修正したコードについてレビューを実施し、結果はプルリクエストのレビューコメントとして書く。

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,10 +115,9 @@ pub fn get_config_dir() -> Result<PathBuf, AppConfigError> {
 }
 
 pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigError> {
-    let config: AppConfig = serde_json::from_str(json_str)
-        .map_err(|e| AppConfigError {
-            message: format!("JSON パースエラー: {}", e),
-        })?;
+    let config: AppConfig = serde_json::from_str(json_str).map_err(|e| AppConfigError {
+        message: format!("JSON パースエラー: {}", e),
+    })?;
 
     validate_config(&config)?;
     Ok(config)
@@ -161,10 +160,7 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
     for layout in &config.layouts {
         if layout.displays.is_empty() {
             return Err(AppConfigError {
-                message: format!(
-                    "レイアウト '{}' のディスプレイが空です",
-                    layout.name
-                ),
+                message: format!("レイアウト '{}' のディスプレイが空です", layout.name),
             });
         }
 
@@ -172,10 +168,7 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
         for display in &layout.displays {
             if display.windows.is_empty() {
                 return Err(AppConfigError {
-                    message: format!(
-                        "ディスプレイ '{}' のウィンドウが空です",
-                        display.name
-                    ),
+                    message: format!("ディスプレイ '{}' のウィンドウが空です", display.name),
                 });
             }
 
@@ -194,7 +187,10 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
     Ok(())
 }
 
-fn validate_window_config(window: &AppWindowConfig, display_name: &str) -> Result<(), AppConfigError> {
+fn validate_window_config(
+    window: &AppWindowConfig,
+    display_name: &str,
+) -> Result<(), AppConfigError> {
     // 座標が指定されている場合のバリデーション
     if let Some(ref position) = window.position {
         validate_position(position).map_err(|e| AppConfigError {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,20 +2,24 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+#[allow(dead_code)]
 const SUPPORTED_VERSION: &str = "1.0";
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PositionValue {
     Left,
     Right,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerticalPositionValue {
     Top,
     Bottom,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SizeValue {
     Half,
@@ -107,6 +111,7 @@ impl std::fmt::Display for AppConfigError {
 
 impl std::error::Error for AppConfigError {}
 
+#[allow(dead_code)]
 pub fn get_config_dir() -> Result<PathBuf, AppConfigError> {
     let home = dirs::home_dir().ok_or_else(|| AppConfigError {
         message: "ホームディレクトリの取得に失敗しました".to_string(),
@@ -114,6 +119,7 @@ pub fn get_config_dir() -> Result<PathBuf, AppConfigError> {
     Ok(home.join(".config/apptidying"))
 }
 
+#[allow(dead_code)]
 pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigError> {
     let config: AppConfig = serde_json::from_str(json_str).map_err(|e| AppConfigError {
         message: format!("JSON パースエラー: {}", e),
@@ -123,6 +129,7 @@ pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigErro
     Ok(config)
 }
 
+#[allow(dead_code)]
 pub fn load_config_file(path: &PathBuf) -> Result<AppConfig, AppConfigError> {
     let content = fs::read_to_string(path).map_err(|e| AppConfigError {
         message: format!("ファイル読み込みエラー ({}): {}", path.display(), e),
@@ -131,6 +138,7 @@ pub fn load_config_file(path: &PathBuf) -> Result<AppConfig, AppConfigError> {
     parse_config_from_json(&content)
 }
 
+#[allow(dead_code)]
 pub fn load_default_config() -> Result<AppConfig, AppConfigError> {
     let config_dir = get_config_dir()?;
     let config_path = config_dir.join("settings.json");
@@ -138,6 +146,7 @@ pub fn load_default_config() -> Result<AppConfig, AppConfigError> {
     load_config_file(&config_path)
 }
 
+#[allow(dead_code)]
 fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
     // バージョンチェック
     if config.version != SUPPORTED_VERSION {
@@ -187,6 +196,7 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn validate_window_config(
     window: &AppWindowConfig,
     display_name: &str,
@@ -214,6 +224,7 @@ fn validate_window_config(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn validate_value(
     value: &serde_json::Value,
     field_name: &str,
@@ -258,18 +269,21 @@ fn validate_value(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn validate_position(position: &Position) -> Result<(), AppConfigError> {
     validate_value(&position.x, "x", &["left", "right"], 0)?;
     validate_value(&position.y, "y", &["top", "bottom"], 0)?;
     Ok(())
 }
 
+#[allow(dead_code)]
 fn validate_size(size: &Size) -> Result<(), AppConfigError> {
     validate_value(&size.width, "width", &["half", "third", "max"], 1)?;
     validate_value(&size.height, "height", &["half", "third", "max"], 1)?;
     Ok(())
 }
 
+#[allow(dead_code)]
 fn validate_notification_config(notification: &NotificationConfig) -> Result<(), AppConfigError> {
     let valid_values = ["notification", "dialog", "none"];
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,129 +218,59 @@ fn validate_window_config(window: &AppWindowConfig, display_name: &str) -> Resul
     Ok(())
 }
 
+fn validate_value(
+    value: &serde_json::Value,
+    field_name: &str,
+    allowed_strings: &[&str],
+    min_numeric: i64,
+) -> Result<(), AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => {
+            if !allowed_strings.contains(&s.as_str()) {
+                return Err(AppConfigError {
+                    message: format!(
+                        "無効な {} 値: '{}' ({} を指定)",
+                        field_name,
+                        s,
+                        allowed_strings.join(", ")
+                    ),
+                });
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < min_numeric {
+                    return Err(AppConfigError {
+                        message: if min_numeric == 0 {
+                            format!("{} が負です", field_name)
+                        } else {
+                            format!("{} は正の数値である必要があります", field_name)
+                        },
+                    });
+                }
+            }
+        }
+        serde_json::Value::Null => {
+            // null は許可
+        }
+        _ => {
+            return Err(AppConfigError {
+                message: format!("{} は文字列または数値である必要があります", field_name),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_position(position: &Position) -> Result<(), AppConfigError> {
-    // x 値のチェック
-    match &position.x {
-        serde_json::Value::String(s) => {
-            if !["left", "right"].contains(&s.as_str()) {
-                return Err(AppConfigError {
-                    message: format!("無効な x 値: '{}' (left または right を指定)", s),
-                });
-            }
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i < 0 {
-                    return Err(AppConfigError {
-                        message: "x 座標が負です".to_string(),
-                    });
-                }
-            }
-        }
-        serde_json::Value::Null => {
-            // null は許可
-        }
-        _ => {
-            return Err(AppConfigError {
-                message: "x は文字列または数値である必要があります".to_string(),
-            });
-        }
-    }
-
-    // y 値のチェック
-    match &position.y {
-        serde_json::Value::String(s) => {
-            if !["top", "bottom"].contains(&s.as_str()) {
-                return Err(AppConfigError {
-                    message: format!("無効な y 値: '{}' (top または bottom を指定)", s),
-                });
-            }
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i < 0 {
-                    return Err(AppConfigError {
-                        message: "y 座標が負です".to_string(),
-                    });
-                }
-            }
-        }
-        serde_json::Value::Null => {
-            // null は許可
-        }
-        _ => {
-            return Err(AppConfigError {
-                message: "y は文字列または数値である必要があります".to_string(),
-            });
-        }
-    }
-
+    validate_value(&position.x, "x", &["left", "right"], 0)?;
+    validate_value(&position.y, "y", &["top", "bottom"], 0)?;
     Ok(())
 }
 
 fn validate_size(size: &Size) -> Result<(), AppConfigError> {
-    // width のチェック
-    match &size.width {
-        serde_json::Value::String(s) => {
-            if !["half", "third", "max"].contains(&s.as_str()) {
-                return Err(AppConfigError {
-                    message: format!(
-                        "無効な width 値: '{}' (half, third または max を指定)",
-                        s
-                    ),
-                });
-            }
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i <= 0 {
-                    return Err(AppConfigError {
-                        message: "width は正の数値である必要があります".to_string(),
-                    });
-                }
-            }
-        }
-        serde_json::Value::Null => {
-            // null は許可
-        }
-        _ => {
-            return Err(AppConfigError {
-                message: "width は文字列または数値である必要があります".to_string(),
-            });
-        }
-    }
-
-    // height のチェック
-    match &size.height {
-        serde_json::Value::String(s) => {
-            if !["half", "third", "max"].contains(&s.as_str()) {
-                return Err(AppConfigError {
-                    message: format!(
-                        "無効な height 値: '{}' (half, third または max を指定)",
-                        s
-                    ),
-                });
-            }
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i <= 0 {
-                    return Err(AppConfigError {
-                        message: "height は正の数値である必要があります".to_string(),
-                    });
-                }
-            }
-        }
-        serde_json::Value::Null => {
-            // null は許可
-        }
-        _ => {
-            return Err(AppConfigError {
-                message: "height は文字列または数値である必要があります".to_string(),
-            });
-        }
-    }
-
+    validate_value(&size.width, "width", &["half", "third", "max"], 1)?;
+    validate_value(&size.height, "height", &["half", "third", "max"], 1)?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,18 +62,26 @@ pub struct LayoutConfig {
     pub displays: Vec<DisplayConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct NotificationConfig {
-    #[serde(default = "default_notification_level")]
-    pub info: String,
-    #[serde(default = "default_notification_level")]
-    pub warn: String,
-    #[serde(default = "default_notification_level")]
-    pub error: String,
+fn default_notification_info() -> String {
+    "notification".to_string()
 }
 
-fn default_notification_level() -> String {
+fn default_notification_warn() -> String {
     "notification".to_string()
+}
+
+fn default_notification_error() -> String {
+    "dialog".to_string()
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NotificationConfig {
+    #[serde(default = "default_notification_info")]
+    pub info: String,
+    #[serde(default = "default_notification_warn")]
+    pub warn: String,
+    #[serde(default = "default_notification_error")]
+    pub error: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -99,9 +107,11 @@ impl std::fmt::Display for AppConfigError {
 
 impl std::error::Error for AppConfigError {}
 
-pub fn get_config_dir() -> PathBuf {
-    let home = dirs::home_dir().expect("Failed to get home directory");
-    home.join(".config/apptidying")
+pub fn get_config_dir() -> Result<PathBuf, AppConfigError> {
+    let home = dirs::home_dir().ok_or_else(|| AppConfigError {
+        message: "ホームディレクトリの取得に失敗しました".to_string(),
+    })?;
+    Ok(home.join(".config/apptidying"))
 }
 
 pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigError> {
@@ -123,7 +133,7 @@ pub fn load_config_file(path: &PathBuf) -> Result<AppConfig, AppConfigError> {
 }
 
 pub fn load_default_config() -> Result<AppConfig, AppConfigError> {
-    let config_dir = get_config_dir();
+    let config_dir = get_config_dir()?;
     let config_path = config_dir.join("settings.json");
 
     load_config_file(&config_path)
@@ -171,7 +181,7 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
 
             // ウィンドウの座標・サイズをチェック
             for window in &display.windows {
-                validate_window_config(window)?;
+                validate_window_config(window, &display.name)?;
             }
         }
     }
@@ -184,15 +194,25 @@ fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
     Ok(())
 }
 
-fn validate_window_config(window: &AppWindowConfig) -> Result<(), AppConfigError> {
+fn validate_window_config(window: &AppWindowConfig, display_name: &str) -> Result<(), AppConfigError> {
     // 座標が指定されている場合のバリデーション
     if let Some(ref position) = window.position {
-        validate_position(position)?;
+        validate_position(position).map_err(|e| AppConfigError {
+            message: format!(
+                "ディスプレイ '{}' のアプリ '{}' のウィンドウ設定でエラー: {}",
+                display_name, window.app, e.message
+            ),
+        })?;
     }
 
     // サイズが指定されている場合のバリデーション
     if let Some(ref size) = window.size {
-        validate_size(size)?;
+        validate_size(size).map_err(|e| AppConfigError {
+            message: format!(
+                "ディスプレイ '{}' のアプリ '{}' のウィンドウ設定でエラー: {}",
+                display_name, window.app, e.message
+            ),
+        })?;
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,48 +2,357 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct WindowLayout {
-    pub app_name: String,
-    pub window_title: String,
-    pub x: i32,
-    pub y: i32,
-    pub width: i32,
-    pub height: i32,
+const SUPPORTED_VERSION: &str = "1.0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PositionValue {
+    Left,
+    Right,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalPositionValue {
+    Top,
+    Bottom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SizeValue {
+    Half,
+    Third,
+    Max,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Position {
+    #[serde(default)]
+    pub x: serde_json::Value,
+    #[serde(default)]
+    pub y: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Size {
+    #[serde(default)]
+    pub width: serde_json::Value,
+    #[serde(default)]
+    pub height: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AppWindowConfig {
+    pub app: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub position: Option<Position>,
+    #[serde(default)]
+    pub size: Option<Size>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DisplayConfig {
+    pub name: String,
+    pub windows: Vec<AppWindowConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LayoutConfig {
     pub name: String,
-    pub windows: Vec<WindowLayout>,
+    pub displays: Vec<DisplayConfig>,
 }
 
-#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NotificationConfig {
+    #[serde(default = "default_notification_level")]
+    pub info: String,
+    #[serde(default = "default_notification_level")]
+    pub warn: String,
+    #[serde(default = "default_notification_level")]
+    pub error: String,
+}
+
+fn default_notification_level() -> String {
+    "notification".to_string()
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AppConfig {
+    pub version: String,
+    pub layouts: Vec<LayoutConfig>,
+    #[serde(default)]
+    pub notification: Option<NotificationConfig>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct AppConfigError {
+    pub message: String,
+}
+
+impl std::fmt::Display for AppConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for AppConfigError {}
+
 pub fn get_config_dir() -> PathBuf {
     let home = dirs::home_dir().expect("Failed to get home directory");
-    home.join(".config/app-tidying")
+    home.join(".config/apptidying")
 }
 
-#[allow(dead_code)]
-pub fn load_layout(layout_name: &str) -> Result<LayoutConfig, Box<dyn std::error::Error>> {
-    let config_dir = get_config_dir();
-    let config_path = config_dir.join(format!("{}.json", layout_name));
+pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigError> {
+    let config: AppConfig = serde_json::from_str(json_str)
+        .map_err(|e| AppConfigError {
+            message: format!("JSON パースエラー: {}", e),
+        })?;
 
-    let content = fs::read_to_string(&config_path)?;
-    let config = serde_json::from_str(&content)?;
-
+    validate_config(&config)?;
     Ok(config)
 }
 
-#[allow(dead_code)]
-pub fn save_layout(layout: &LayoutConfig) -> Result<(), Box<dyn std::error::Error>> {
+pub fn load_config_file(path: &PathBuf) -> Result<AppConfig, AppConfigError> {
+    let content = fs::read_to_string(path).map_err(|e| AppConfigError {
+        message: format!("ファイル読み込みエラー ({}): {}", path.display(), e),
+    })?;
+
+    parse_config_from_json(&content)
+}
+
+pub fn load_default_config() -> Result<AppConfig, AppConfigError> {
     let config_dir = get_config_dir();
+    let config_path = config_dir.join("settings.json");
 
-    fs::create_dir_all(&config_dir)?;
+    load_config_file(&config_path)
+}
 
-    let config_path = config_dir.join(format!("{}.json", layout.name));
-    let json = serde_json::to_string_pretty(layout)?;
-    fs::write(&config_path, json)?;
+fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
+    // バージョンチェック
+    if config.version != SUPPORTED_VERSION {
+        return Err(AppConfigError {
+            message: format!(
+                "サポートされていないバージョン: {}（サポート: {}）",
+                config.version, SUPPORTED_VERSION
+            ),
+        });
+    }
+
+    // レイアウトが空でないかチェック
+    if config.layouts.is_empty() {
+        return Err(AppConfigError {
+            message: "layouts フィールドが空です".to_string(),
+        });
+    }
+
+    // 各レイアウトのディスプレイをチェック
+    for layout in &config.layouts {
+        if layout.displays.is_empty() {
+            return Err(AppConfigError {
+                message: format!(
+                    "レイアウト '{}' のディスプレイが空です",
+                    layout.name
+                ),
+            });
+        }
+
+        // 各ディスプレイのウィンドウをチェック
+        for display in &layout.displays {
+            if display.windows.is_empty() {
+                return Err(AppConfigError {
+                    message: format!(
+                        "ディスプレイ '{}' のウィンドウが空です",
+                        display.name
+                    ),
+                });
+            }
+
+            // ウィンドウの座標・サイズをチェック
+            for window in &display.windows {
+                validate_window_config(window)?;
+            }
+        }
+    }
+
+    // 通知設定の検証
+    if let Some(ref notification) = config.notification {
+        validate_notification_config(notification)?;
+    }
+
+    Ok(())
+}
+
+fn validate_window_config(window: &AppWindowConfig) -> Result<(), AppConfigError> {
+    // 座標が指定されている場合のバリデーション
+    if let Some(ref position) = window.position {
+        validate_position(position)?;
+    }
+
+    // サイズが指定されている場合のバリデーション
+    if let Some(ref size) = window.size {
+        validate_size(size)?;
+    }
+
+    Ok(())
+}
+
+fn validate_position(position: &Position) -> Result<(), AppConfigError> {
+    // x 値のチェック
+    match &position.x {
+        serde_json::Value::String(s) => {
+            if !["left", "right"].contains(&s.as_str()) {
+                return Err(AppConfigError {
+                    message: format!("無効な x 値: '{}' (left または right を指定)", s),
+                });
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    return Err(AppConfigError {
+                        message: "x 座標が負です".to_string(),
+                    });
+                }
+            }
+        }
+        serde_json::Value::Null => {
+            // null は許可
+        }
+        _ => {
+            return Err(AppConfigError {
+                message: "x は文字列または数値である必要があります".to_string(),
+            });
+        }
+    }
+
+    // y 値のチェック
+    match &position.y {
+        serde_json::Value::String(s) => {
+            if !["top", "bottom"].contains(&s.as_str()) {
+                return Err(AppConfigError {
+                    message: format!("無効な y 値: '{}' (top または bottom を指定)", s),
+                });
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    return Err(AppConfigError {
+                        message: "y 座標が負です".to_string(),
+                    });
+                }
+            }
+        }
+        serde_json::Value::Null => {
+            // null は許可
+        }
+        _ => {
+            return Err(AppConfigError {
+                message: "y は文字列または数値である必要があります".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_size(size: &Size) -> Result<(), AppConfigError> {
+    // width のチェック
+    match &size.width {
+        serde_json::Value::String(s) => {
+            if !["half", "third", "max"].contains(&s.as_str()) {
+                return Err(AppConfigError {
+                    message: format!(
+                        "無効な width 値: '{}' (half, third または max を指定)",
+                        s
+                    ),
+                });
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i <= 0 {
+                    return Err(AppConfigError {
+                        message: "width は正の数値である必要があります".to_string(),
+                    });
+                }
+            }
+        }
+        serde_json::Value::Null => {
+            // null は許可
+        }
+        _ => {
+            return Err(AppConfigError {
+                message: "width は文字列または数値である必要があります".to_string(),
+            });
+        }
+    }
+
+    // height のチェック
+    match &size.height {
+        serde_json::Value::String(s) => {
+            if !["half", "third", "max"].contains(&s.as_str()) {
+                return Err(AppConfigError {
+                    message: format!(
+                        "無効な height 値: '{}' (half, third または max を指定)",
+                        s
+                    ),
+                });
+            }
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i <= 0 {
+                    return Err(AppConfigError {
+                        message: "height は正の数値である必要があります".to_string(),
+                    });
+                }
+            }
+        }
+        serde_json::Value::Null => {
+            // null は許可
+        }
+        _ => {
+            return Err(AppConfigError {
+                message: "height は文字列または数値である必要があります".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_notification_config(notification: &NotificationConfig) -> Result<(), AppConfigError> {
+    let valid_values = ["notification", "dialog", "none"];
+
+    if !valid_values.contains(&notification.info.as_str()) {
+        return Err(AppConfigError {
+            message: format!(
+                "無効な notification.info 値: '{}' (notification, dialog または none を指定)",
+                notification.info
+            ),
+        });
+    }
+
+    if !valid_values.contains(&notification.warn.as_str()) {
+        return Err(AppConfigError {
+            message: format!(
+                "無効な notification.warn 値: '{}' (notification, dialog または none を指定)",
+                notification.warn
+            ),
+        });
+    }
+
+    if !valid_values.contains(&notification.error.as_str()) {
+        return Err(AppConfigError {
+            message: format!(
+                "無効な notification.error 値: '{}' (notification, dialog または none を指定)",
+                notification.error
+            ),
+        });
+    }
 
     Ok(())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,5 @@
 use apptidying::cli::Cli;
+use apptidying::config;
 use clap::Parser;
 
 #[test]
@@ -6,4 +7,479 @@ fn test_cli_parser() {
     let args = vec!["app-tidying"];
     let cli = Cli::try_parse_from(&args);
     assert!(cli.is_ok());
+}
+
+#[test]
+fn test_parse_valid_config() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "development",
+                "displays": [
+                    {
+                        "name": "Built-in",
+                        "windows": [
+                            {
+                                "app": "Google Chrome",
+                                "title": "Development",
+                                "position": { "x": 0, "y": 25 },
+                                "size": { "width": 1440, "height": 900 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_ok());
+    let cfg = config.unwrap();
+    assert_eq!(cfg.version, "1.0");
+    assert_eq!(cfg.layouts.len(), 1);
+    assert_eq!(cfg.layouts[0].name, "development");
+    assert_eq!(cfg.layouts[0].displays[0].name, "Built-in");
+}
+
+#[test]
+fn test_parse_config_with_pattern_values() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "position": { "x": "left", "y": "top" },
+                                "size": { "width": "half", "height": "max" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_ok());
+}
+
+#[test]
+fn test_parse_config_missing_version() {
+    let json = r#"{
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": []
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+}
+
+#[test]
+fn test_parse_config_unsupported_version() {
+    let json = r#"{
+        "version": "2.0",
+        "layouts": []
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("サポートされていないバージョン"));
+}
+
+#[test]
+fn test_parse_config_empty_layouts() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": []
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("layouts フィールドが空"));
+}
+
+#[test]
+fn test_parse_config_empty_displays() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": []
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("ディスプレイが空"));
+}
+
+#[test]
+fn test_parse_config_empty_windows() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": []
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("ウィンドウが空"));
+}
+
+#[test]
+fn test_parse_config_invalid_position_x() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "position": { "x": "invalid", "y": "top" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("無効な x 値"));
+}
+
+#[test]
+fn test_parse_config_invalid_position_y() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "position": { "x": "left", "y": "invalid" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("無効な y 値"));
+}
+
+#[test]
+fn test_parse_config_invalid_size_width() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "size": { "width": "invalid" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("無効な width 値"));
+}
+
+#[test]
+fn test_parse_config_invalid_size_height() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "size": { "height": "invalid" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("無効な height 値"));
+}
+
+#[test]
+fn test_parse_config_negative_coordinates() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "position": { "x": -10, "y": 0 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("座標が負"));
+}
+
+#[test]
+fn test_parse_config_zero_or_negative_size() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder",
+                                "size": { "width": 0 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("正の数値"));
+}
+
+#[test]
+fn test_parse_config_with_notification_settings() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "notification": {
+            "info": "notification",
+            "warn": "notification",
+            "error": "dialog"
+        }
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_ok());
+    let cfg = config.unwrap();
+    assert!(cfg.notification.is_some());
+    let notif = cfg.notification.unwrap();
+    assert_eq!(notif.info, "notification");
+    assert_eq!(notif.error, "dialog");
+}
+
+#[test]
+fn test_parse_config_invalid_notification_value() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "notification": {
+            "info": "invalid"
+        }
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_err());
+    assert!(config
+        .unwrap_err()
+        .message
+        .contains("無効な notification.info 値"));
+}
+
+#[test]
+fn test_parse_config_with_timeout() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "Finder"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "timeout": 5000
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_ok());
+    let cfg = config.unwrap();
+    assert_eq!(cfg.timeout, Some(5000));
+}
+
+#[test]
+fn test_parse_config_multiple_layouts_and_displays() {
+    let json = r#"{
+        "version": "1.0",
+        "layouts": [
+            {
+                "name": "layout1",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "App1"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Display 2",
+                        "windows": [
+                            {
+                                "app": "App2"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "layout2",
+                "displays": [
+                    {
+                        "name": "Display 1",
+                        "windows": [
+                            {
+                                "app": "App3"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let config = config::parse_config_from_json(json);
+    assert!(config.is_ok());
+    let cfg = config.unwrap();
+    assert_eq!(cfg.layouts.len(), 2);
+    assert_eq!(cfg.layouts[0].displays.len(), 2);
+    assert_eq!(cfg.layouts[1].displays.len(), 1);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -128,10 +128,7 @@ fn test_parse_config_empty_displays() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("ディスプレイが空"));
+    assert!(config.unwrap_err().message.contains("ディスプレイが空"));
 }
 
 #[test]
@@ -153,10 +150,7 @@ fn test_parse_config_empty_windows() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("ウィンドウが空"));
+    assert!(config.unwrap_err().message.contains("ウィンドウが空"));
 }
 
 #[test]
@@ -183,10 +177,7 @@ fn test_parse_config_invalid_position_x() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("無効な x 値"));
+    assert!(config.unwrap_err().message.contains("無効な x 値"));
 }
 
 #[test]
@@ -213,10 +204,7 @@ fn test_parse_config_invalid_position_y() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("無効な y 値"));
+    assert!(config.unwrap_err().message.contains("無効な y 値"));
 }
 
 #[test]
@@ -243,10 +231,7 @@ fn test_parse_config_invalid_size_width() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("無効な width 値"));
+    assert!(config.unwrap_err().message.contains("無効な width 値"));
 }
 
 #[test]
@@ -273,10 +258,7 @@ fn test_parse_config_invalid_size_height() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("無効な height 値"));
+    assert!(config.unwrap_err().message.contains("無効な height 値"));
 }
 
 #[test]
@@ -303,10 +285,7 @@ fn test_parse_config_negative_coordinates() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("が負です"));
+    assert!(config.unwrap_err().message.contains("が負です"));
 }
 
 #[test]
@@ -333,10 +312,7 @@ fn test_parse_config_zero_or_negative_size() {
 
     let config = config::parse_config_from_json(json);
     assert!(config.is_err());
-    assert!(config
-        .unwrap_err()
-        .message
-        .contains("正の数値"));
+    assert!(config.unwrap_err().message.contains("正の数値"));
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -306,7 +306,7 @@ fn test_parse_config_negative_coordinates() {
     assert!(config
         .unwrap_err()
         .message
-        .contains("座標が負"));
+        .contains("が負です"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

JSONスキーマの定義とRustでのパーサを実装しました。serde_jsonを使用してJSON構造体のデシリアライズを行い、CLAUDE.mdで定義された仕様に基づいた包括的なバリデーション機能を実装しています。

- AppConfig, DisplayConfig, AppWindowConfigなどの構造体定義
- Position, Size, NotificationConfigのサポート
- バージョン番号チェック（v1.0のみサポート）
- 座標・サイズの妥当性チェック（負の値、無効な値の検出）
- 通知設定のバリデーション
- 18個のユニットテスト（正常系・エラー系両方をカバー）

## Test plan

- [x] `cargo test` でのテスト実行確認（全18テスト成功）
- [x] 有効なJSON設定のパース確認
- [x] パターン値（left, right, top, bottom, half, third, max）のサポート確認
- [x] 無効なバージョン、空のフィールド、不正な座標・サイズのエラーハンドリング確認

Closes #20

🤖 Generated with Claude Code