### PR TITLE
feat: P2-1-2: ウィンドウ位置・サイズ変更スクリプト実装

### DIFF
--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -219,3 +219,306 @@ pub fn launch_or_activate_app(
         was_already_running: false,
     })
 }
+
+// =============================================================================
+// Display Information
+// =============================================================================
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DisplayInfo {
+    pub name: String,
+    pub width: i32,
+    pub height: i32,
+    pub origin_x: i32,
+    pub origin_y: i32,
+}
+
+impl DisplayInfo {
+    #[allow(dead_code)]
+    pub fn to_json(&self) -> Value {
+        json!({
+            "name": self.name,
+            "width": self.width,
+            "height": self.height,
+            "origin_x": self.origin_x,
+            "origin_y": self.origin_y,
+        })
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct DisplayError {
+    pub message: String,
+}
+
+impl std::fmt::Display for DisplayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for DisplayError {}
+
+/// Get display information using JXA and AppleScript
+#[allow(dead_code)]
+pub fn get_display_info(display_name: Option<&str>) -> Result<DisplayInfo, DisplayError> {
+    // Get all displays using JXA
+    let jxa_script = r#"
+ObjC.import('AppKit')
+
+const screens = $.NSScreen.screens
+let targetDisplay = null
+
+if (screens.count === 0) {
+    "error: no displays found"
+} else {
+    let searchName = null
+    if (ObjC.unwrap(arguments[0]) !== null) {
+        searchName = ObjC.unwrap(arguments[0])
+    }
+
+    for (let i = 0; i < screens.count; i++) {
+        const screen = screens.objectAtIndex(i)
+        const displayName = ObjC.unwrap(screen.localizedName) || "Unknown"
+
+        if (searchName === null || displayName === searchName) {
+            const frame = screen.frame
+            const result = {
+                name: displayName,
+                width: Math.round(frame.size.width),
+                height: Math.round(frame.size.height),
+                origin_x: Math.round(frame.origin.x),
+                origin_y: Math.round(frame.origin.y)
+            }
+            targetDisplay = result
+            break
+        }
+    }
+
+    if (targetDisplay === null && searchName !== null) {
+        // Display with specified name not found, use main display
+        const mainScreen = $.NSScreen.mainScreen
+        const displayName = ObjC.unwrap(mainScreen.localizedName) || "Main"
+        const frame = mainScreen.frame
+        const result = {
+            name: displayName,
+            width: Math.round(frame.size.width),
+            height: Math.round(frame.size.height),
+            origin_x: Math.round(frame.origin.x),
+            origin_y: Math.round(frame.origin.y)
+        }
+        targetDisplay = result
+    } else if (targetDisplay === null) {
+        // Use main display if no specific name requested
+        const mainScreen = $.NSScreen.mainScreen
+        const displayName = ObjC.unwrap(mainScreen.localizedName) || "Main"
+        const frame = mainScreen.frame
+        const result = {
+            name: displayName,
+            width: Math.round(frame.size.width),
+            height: Math.round(frame.size.height),
+            origin_x: Math.round(frame.origin.x),
+            origin_y: Math.round(frame.origin.y)
+        }
+        targetDisplay = result
+    }
+
+    JSON.stringify(targetDisplay)
+}
+"#;
+
+    let output = Command::new("osascript")
+        .arg("-l")
+        .arg("JavaScript")
+        .arg("-e")
+        .arg(jxa_script)
+        .arg(display_name.unwrap_or(""))
+        .output()
+        .map_err(|e| DisplayError {
+            message: format!("osascriptの実行に失敗しました: {}", e),
+        })?;
+
+    if !output.status.success() {
+        return Err(DisplayError {
+            message: format!(
+                "ディスプレイ情報取得に失敗しました: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        });
+    }
+
+    let result_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    let json_value: serde_json::Value =
+        serde_json::from_str(&result_str).map_err(|e| DisplayError {
+            message: format!("ディスプレイ情報のパースに失敗しました: {}", e),
+        })?;
+
+    let display_info = DisplayInfo {
+        name: json_value["name"]
+            .as_str()
+            .ok_or_else(|| DisplayError {
+                message: "ディスプレイ名の取得に失敗しました".to_string(),
+            })?
+            .to_string(),
+        width: json_value["width"].as_i64().ok_or_else(|| DisplayError {
+            message: "ディスプレイ幅の取得に失敗しました".to_string(),
+        })? as i32,
+        height: json_value["height"].as_i64().ok_or_else(|| DisplayError {
+            message: "ディスプレイ高さの取得に失敗しました".to_string(),
+        })? as i32,
+        origin_x: json_value["origin_x"]
+            .as_i64()
+            .ok_or_else(|| DisplayError {
+                message: "ディスプレイ原点X座標の取得に失敗しました".to_string(),
+            })? as i32,
+        origin_y: json_value["origin_y"]
+            .as_i64()
+            .ok_or_else(|| DisplayError {
+                message: "ディスプレイ原点Y座標の取得に失敗しました".to_string(),
+            })? as i32,
+    };
+
+    Ok(display_info)
+}
+
+// =============================================================================
+// Window Resize
+// =============================================================================
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct WindowResizeResult {
+    pub status: String,
+    pub message: String,
+    pub new_position: Option<(i32, i32)>,
+    pub new_size: Option<(i32, i32)>,
+}
+
+impl WindowResizeResult {
+    #[allow(dead_code)]
+    pub fn to_json(&self) -> Value {
+        let mut obj = json!({
+            "status": self.status,
+            "message": self.message,
+        });
+
+        if let Some((x, y)) = self.new_position {
+            obj["new_position"] = json!({"x": x, "y": y});
+        }
+
+        if let Some((width, height)) = self.new_size {
+            obj["new_size"] = json!({"width": width, "height": height});
+        }
+
+        obj
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct WindowResizeError {
+    pub message: String,
+}
+
+impl std::fmt::Display for WindowResizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for WindowResizeError {}
+
+/// Resize and move a window
+#[allow(dead_code)]
+pub fn resize_window(
+    app_name: &str,
+    window_title: Option<&str>,
+    position: Option<(i32, i32)>,
+    size: Option<(i32, i32)>,
+) -> Result<WindowResizeResult, WindowResizeError> {
+    // Build AppleScript to resize window
+    let mut script = format!(
+        r#"
+tell application "System Events"
+    try
+        tell process "{}"
+"#,
+        escape_applescript_string(app_name)
+    );
+
+    // Select window by title or use first window
+    if let Some(title) = window_title {
+        script.push_str(&format!(
+            r#"
+            set targetWindow to first window whose name contains "{}"
+"#,
+            escape_applescript_string(title)
+        ));
+    } else {
+        script.push_str(
+            r#"
+            set targetWindow to window 1
+"#,
+        );
+    }
+
+    // Set position if provided
+    if let Some((x, y)) = position {
+        script.push_str(&format!(
+            r#"
+            set position of targetWindow to {{{}, {}}}
+"#,
+            x, y
+        ));
+    }
+
+    // Set size if provided
+    if let Some((width, height)) = size {
+        script.push_str(&format!(
+            r#"
+            set size of targetWindow to {{{}, {}}}
+"#,
+            width, height
+        ));
+    }
+
+    script.push_str(
+        r#"
+            return "success"
+        on error errMsg
+            return "error: " & errMsg
+        end try
+    end tell
+end tell
+"#,
+    );
+
+    let output = run_osascript(&script).map_err(|e| WindowResizeError { message: e.message })?;
+
+    if !output.status.success() {
+        return Err(WindowResizeError {
+            message: format!(
+                "ウィンドウのリサイズに失敗しました: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        });
+    }
+
+    let result_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if result_str.contains("error") {
+        return Err(WindowResizeError {
+            message: result_str,
+        });
+    }
+
+    Ok(WindowResizeResult {
+        status: "success".to_string(),
+        message: "ウィンドウをリサイズしました".to_string(),
+        new_position: position,
+        new_size: size,
+    })
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,3 +316,212 @@ fn validate_notification_config(notification: &NotificationConfig) -> Result<(),
 
     Ok(())
 }
+
+// =============================================================================
+// Pattern Calculation Functions
+// =============================================================================
+
+/// Parse position value to absolute coordinates
+/// Returns (x, y) coordinates
+#[allow(dead_code, clippy::too_many_arguments)]
+pub fn parse_position_value(
+    value: &serde_json::Value,
+    display_width: i32,
+    display_height: i32,
+    window_width: i32,
+    window_height: i32,
+    field_name: &str,
+) -> Result<(i32, i32), AppConfigError> {
+    match value {
+        serde_json::Value::Object(obj) => {
+            let x = obj.get("x").ok_or_else(|| AppConfigError {
+                message: format!("{} に x フィールドが見つかりません", field_name),
+            })?;
+
+            let y = obj.get("y").ok_or_else(|| AppConfigError {
+                message: format!("{} に y フィールドが見つかりません", field_name),
+            })?;
+
+            let x_val = parse_x_value(x, display_width, window_width)?;
+            let y_val = parse_y_value(y, display_height, window_height)?;
+
+            Ok((x_val, y_val))
+        }
+        _ => Err(AppConfigError {
+            message: format!("{} はオブジェクトである必要があります", field_name),
+        }),
+    }
+}
+
+/// Parse x coordinate value
+fn parse_x_value(
+    value: &serde_json::Value,
+    display_width: i32,
+    window_width: i32,
+) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "left" => Ok(0),
+            "right" => Ok(display_width - window_width),
+            _ => Err(AppConfigError {
+                message: format!("無効な x 値: '{}' (left, right を指定)", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Err(AppConfigError {
+                        message: "x が負です".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "x は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "x は文字列または数値である必要があります".to_string(),
+        }),
+    }
+}
+
+/// Parse y coordinate value
+fn parse_y_value(
+    value: &serde_json::Value,
+    display_height: i32,
+    window_height: i32,
+) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "top" => Ok(25), // Menu bar height is assumed to be 25px
+            "bottom" => Ok(display_height - window_height),
+            _ => Err(AppConfigError {
+                message: format!("無効な y 値: '{}' (top, bottom を指定)", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Err(AppConfigError {
+                        message: "y が負です".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "y は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "y は文字列または数値である必要があります".to_string(),
+        }),
+    }
+}
+
+/// Parse size value to absolute dimensions
+/// Returns (width, height) dimensions
+#[allow(dead_code)]
+pub fn parse_size_value(
+    value: &serde_json::Value,
+    display_width: i32,
+    display_height: i32,
+    field_name: &str,
+) -> Result<(i32, i32), AppConfigError> {
+    match value {
+        serde_json::Value::Object(obj) => {
+            let width = obj.get("width").ok_or_else(|| AppConfigError {
+                message: format!("{} に width フィールドが見つかりません", field_name),
+            })?;
+
+            let height = obj.get("height").ok_or_else(|| AppConfigError {
+                message: format!("{} に height フィールドが見つかりません", field_name),
+            })?;
+
+            let width_val = parse_width_value(width, display_width)?;
+            let height_val = parse_height_value(height, display_height)?;
+
+            if width_val <= 0 || height_val <= 0 {
+                return Err(AppConfigError {
+                    message: "ウィンドウサイズは正の値である必要があります".to_string(),
+                });
+            }
+
+            Ok((width_val, height_val))
+        }
+        _ => Err(AppConfigError {
+            message: format!("{} はオブジェクトである必要があります", field_name),
+        }),
+    }
+}
+
+/// Parse width value
+fn parse_width_value(value: &serde_json::Value, display_width: i32) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "half" => Ok(display_width / 2),
+            "third" => Ok(display_width / 3),
+            "max" => Ok(display_width),
+            _ => Err(AppConfigError {
+                message: format!("無効な width 値: '{}' (half, third, max を指定)", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i <= 0 {
+                    Err(AppConfigError {
+                        message: "width は正の値である必要があります".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "width は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "width は文字列または数値である必要があります".to_string(),
+        }),
+    }
+}
+
+/// Parse height value
+fn parse_height_value(
+    value: &serde_json::Value,
+    display_height: i32,
+) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "half" => Ok(display_height / 2),
+            "third" => Ok(display_height / 3),
+            "max" => Ok(display_height),
+            _ => Err(AppConfigError {
+                message: format!("無効な height 値: '{}' (half, third, max を指定)", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i <= 0 {
+                    Err(AppConfigError {
+                        message: "height は正の値である必要があります".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "height は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "height は文字列または数値である必要があります".to_string(),
+        }),
+    }
+}

--- a/tests/applescript_test.rs
+++ b/tests/applescript_test.rs
@@ -1536,12 +1536,7 @@ fn test_resize_window_to_json() {
 #[ignore]
 fn test_resize_window_unicode_app_name() {
     // Unicode を含むアプリケーション名
-    let result = resize_window(
-        "日本語アプリ",
-        None,
-        Some((100, 100)),
-        Some((800, 600)),
-    );
+    let result = resize_window("日本語アプリ", None, Some((100, 100)), Some((800, 600)));
 
     // 存在しないアプリケーションなのでエラーが返される
     assert!(result.is_err());

--- a/tests/applescript_test.rs
+++ b/tests/applescript_test.rs
@@ -1215,8 +1215,8 @@ fn test_get_display_info_main_display() {
     // メインディスプレイの情報を取得（display_name = None）
     let result = get_display_info(None);
 
-    if result.is_err() {
-        eprintln!("Error: {:?}", result.as_ref().unwrap_err());
+    if let Err(e) = &result {
+        eprintln!("Error: {:?}", e);
     }
     assert!(result.is_ok());
     let display_info = result.unwrap();
@@ -1391,8 +1391,7 @@ fn test_resize_window_with_title() {
 
     // タイトルが見つからない場合は最初のウィンドウを使用
     // エラーが返される可能性もある
-    if result.is_ok() {
-        let resize_result = result.unwrap();
+    if let Ok(resize_result) = result {
         assert_eq!(resize_result.status, "success");
     }
 }
@@ -1451,8 +1450,7 @@ fn test_resize_window_boundary_large_size() {
     let result = resize_window("Finder", None, Some((0, 0)), Some((5000, 3000)));
 
     // macOS がサイズを制限する可能性があるが、コマンド自体は成功する可能性がある
-    if result.is_ok() {
-        let resize_result = result.unwrap();
+    if let Ok(resize_result) = result {
         assert_eq!(resize_result.new_size, Some((5000, 3000)));
     }
 }
@@ -1469,8 +1467,7 @@ fn test_resize_window_negative_position() {
     // macOS は負の座標を許可する可能性がある（マルチディスプレイ環境）
     // エラーになるかもしれないし、成功するかもしれない
     // ここでは結果のみを確認
-    if result.is_ok() {
-        let resize_result = result.unwrap();
+    if let Ok(resize_result) = result {
         assert_eq!(resize_result.new_position, Some((-100, -100)));
     }
 }
@@ -1519,8 +1516,7 @@ fn test_resize_window_to_json() {
 
     let result = resize_window("Finder", None, Some((150, 150)), Some((850, 650)));
 
-    if result.is_ok() {
-        let resize_result = result.unwrap();
+    if let Ok(resize_result) = result {
         let json = resize_result.to_json();
 
         assert_eq!(json["status"], "success");

--- a/tests/applescript_test.rs
+++ b/tests/applescript_test.rs
@@ -1,5 +1,6 @@
 use apptidying::applescript::{
-    escape_applescript_string, launch_or_activate_app, AppLaunchError, AppLaunchResult,
+    escape_applescript_string, get_display_info, launch_or_activate_app, resize_window,
+    AppLaunchError, AppLaunchResult, DisplayInfo,
 };
 
 // =============================================================================
@@ -1011,4 +1012,599 @@ fn test_edge_case_app_launch_result_json_null_handling() {
 
     // process_id フィールドは含まれない
     assert!(json.get("process_id").is_none());
+}
+
+// =============================================================================
+// DisplayInfo Tests
+// =============================================================================
+
+#[test]
+fn test_display_info_creation() {
+    // DisplayInfo が正しく作成できることを確認
+    let display_info = DisplayInfo {
+        name: "Built-in Display".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    assert_eq!(display_info.name, "Built-in Display");
+    assert_eq!(display_info.width, 1920);
+    assert_eq!(display_info.height, 1080);
+    assert_eq!(display_info.origin_x, 0);
+    assert_eq!(display_info.origin_y, 0);
+}
+
+#[test]
+fn test_display_info_to_json() {
+    // DisplayInfo の JSON 変換
+    let display_info = DisplayInfo {
+        name: "External Display".to_string(),
+        width: 2560,
+        height: 1440,
+        origin_x: 1920,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["name"], "External Display");
+    assert_eq!(json["width"], 2560);
+    assert_eq!(json["height"], 1440);
+    assert_eq!(json["origin_x"], 1920);
+    assert_eq!(json["origin_y"], 0);
+}
+
+#[test]
+fn test_display_info_to_json_negative_origin() {
+    // 負の原点座標を持つディスプレイ（境界値テスト）
+    let display_info = DisplayInfo {
+        name: "Display Left".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: -1920,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["origin_x"], -1920);
+    assert_eq!(json["origin_y"], 0);
+}
+
+#[test]
+fn test_display_info_to_json_4k_display() {
+    // 4K ディスプレイの JSON 変換
+    let display_info = DisplayInfo {
+        name: "4K Display".to_string(),
+        width: 3840,
+        height: 2160,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["width"], 3840);
+    assert_eq!(json["height"], 2160);
+}
+
+#[test]
+fn test_display_info_to_json_small_display() {
+    // 小さいディスプレイの JSON 変換（境界値テスト）
+    let display_info = DisplayInfo {
+        name: "Small Display".to_string(),
+        width: 800,
+        height: 600,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["width"], 800);
+    assert_eq!(json["height"], 600);
+}
+
+#[test]
+fn test_display_info_to_json_empty_name() {
+    // 空の名前を持つディスプレイ（境界値テスト）
+    let display_info = DisplayInfo {
+        name: "".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["name"], "");
+}
+
+#[test]
+fn test_display_info_to_json_unicode_name() {
+    // Unicode を含む名前のディスプレイ
+    let display_info = DisplayInfo {
+        name: "日本語ディスプレイ 🖥️".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["name"], "日本語ディスプレイ 🖥️");
+}
+
+#[test]
+fn test_display_info_to_json_very_large_dimensions() {
+    // 非常に大きいディスプレイサイズ（境界値テスト）
+    let display_info = DisplayInfo {
+        name: "Huge Display".to_string(),
+        width: 10000,
+        height: 10000,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let json = display_info.to_json();
+    assert_eq!(json["width"], 10000);
+    assert_eq!(json["height"], 10000);
+}
+
+#[test]
+fn test_display_info_to_json_all_fields_present() {
+    // JSON に全フィールドが存在することを確認
+    let display_info = DisplayInfo {
+        name: "Test Display".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 100,
+        origin_y: 200,
+    };
+
+    let json = display_info.to_json();
+    assert!(json.get("name").is_some());
+    assert!(json.get("width").is_some());
+    assert!(json.get("height").is_some());
+    assert!(json.get("origin_x").is_some());
+    assert!(json.get("origin_y").is_some());
+}
+
+#[test]
+fn test_display_info_clone() {
+    // Clone トレイトが正しく動作することを確認
+    let display1 = DisplayInfo {
+        name: "Test Display".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let display2 = display1.clone();
+
+    assert_eq!(display1.name, display2.name);
+    assert_eq!(display1.width, display2.width);
+    assert_eq!(display1.height, display2.height);
+    assert_eq!(display1.origin_x, display2.origin_x);
+    assert_eq!(display1.origin_y, display2.origin_y);
+}
+
+#[test]
+fn test_display_info_debug() {
+    // Debug トレイトが実装されていることを確認
+    let display_info = DisplayInfo {
+        name: "Test Display".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    };
+
+    let debug_str = format!("{:?}", display_info);
+    assert!(debug_str.contains("DisplayInfo"));
+    assert!(debug_str.contains("Test Display"));
+    assert!(debug_str.contains("1920"));
+}
+
+// =============================================================================
+// get_display_info() Integration Tests (osascript required)
+// =============================================================================
+
+#[test]
+#[ignore]
+fn test_get_display_info_main_display() {
+    // メインディスプレイの情報を取得（display_name = None）
+    let result = get_display_info(None);
+
+    if result.is_err() {
+        eprintln!("Error: {:?}", result.as_ref().unwrap_err());
+    }
+    assert!(result.is_ok());
+    let display_info = result.unwrap();
+
+    // 名前が空でないことを確認
+    assert!(!display_info.name.is_empty());
+
+    // サイズが正の値であることを確認
+    assert!(display_info.width > 0);
+    assert!(display_info.height > 0);
+
+    // JSON 変換が正しく動作することを確認
+    let json = display_info.to_json();
+    assert!(json.get("name").is_some());
+    assert!(json.get("width").is_some());
+    assert!(json.get("height").is_some());
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_built_in_display() {
+    // "Built-in" ディスプレイを検索
+    // 注: ディスプレイ名は macOS のバージョンや言語設定によって異なる可能性があります
+    let result = get_display_info(Some("Built-in"));
+
+    // ディスプレイが見つからない場合はメインディスプレイにフォールバック
+    assert!(result.is_ok());
+    let display_info = result.unwrap();
+    assert!(display_info.width > 0);
+    assert!(display_info.height > 0);
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_nonexistent_display() {
+    // 存在しないディスプレイ名を指定
+    // メインディスプレイにフォールバックすることを確認
+    let result = get_display_info(Some("NonExistentDisplay123456"));
+
+    assert!(result.is_ok());
+    let display_info = result.unwrap();
+
+    // メインディスプレイにフォールバックするため、成功する
+    assert!(display_info.width > 0);
+    assert!(display_info.height > 0);
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_empty_name() {
+    // 空文字列のディスプレイ名（境界値テスト）
+    let result = get_display_info(Some(""));
+
+    assert!(result.is_ok());
+    let display_info = result.unwrap();
+
+    // メインディスプレイにフォールバックするため、成功する
+    assert!(display_info.width > 0);
+    assert!(display_info.height > 0);
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_unicode_name() {
+    // Unicode を含むディスプレイ名
+    let result = get_display_info(Some("日本語ディスプレイ"));
+
+    // 存在しないディスプレイなので、メインディスプレイにフォールバック
+    assert!(result.is_ok());
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_very_long_name() {
+    // 非常に長いディスプレイ名（境界値テスト）
+    let long_name = "VeryLongDisplayName".to_string() + &"a".repeat(1000);
+    let result = get_display_info(Some(&long_name));
+
+    // 存在しないディスプレイなので、メインディスプレイにフォールバック
+    assert!(result.is_ok());
+}
+
+#[test]
+#[ignore]
+fn test_get_display_info_json_output() {
+    // JSON 出力の詳細テスト
+    let result = get_display_info(None);
+    assert!(result.is_ok());
+
+    let display_info = result.unwrap();
+    let json = display_info.to_json();
+
+    // JSON のすべてのフィールドが存在し、適切な型であることを確認
+    assert!(json["name"].is_string());
+    assert!(json["width"].is_i64() || json["width"].is_u64());
+    assert!(json["height"].is_i64() || json["height"].is_u64());
+    assert!(json["origin_x"].is_i64());
+    assert!(json["origin_y"].is_i64());
+}
+
+// =============================================================================
+// WindowResizeResult Tests
+// =============================================================================
+
+// WindowResizeResult は applescript.rs で公開されていないため、
+// resize_window() を通じて間接的にテスト
+
+// =============================================================================
+// resize_window() Integration Tests (osascript required)
+// =============================================================================
+
+#[test]
+#[ignore]
+fn test_resize_window_finder() {
+    // Finder ウィンドウのリサイズテスト
+    // 注: このテストは実際に Finder ウィンドウを操作します
+
+    // まず Finder を起動
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    // ウィンドウをリサイズ
+    let result = resize_window("Finder", None, Some((100, 100)), Some((800, 600)));
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.status, "success");
+    assert_eq!(resize_result.new_position, Some((100, 100)));
+    assert_eq!(resize_result.new_size, Some((800, 600)));
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_position_only() {
+    // 位置のみ変更
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((200, 200)), None);
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.new_position, Some((200, 200)));
+    assert_eq!(resize_result.new_size, None);
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_size_only() {
+    // サイズのみ変更
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, None, Some((900, 700)));
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.new_position, None);
+    assert_eq!(resize_result.new_size, Some((900, 700)));
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_with_title() {
+    // ウィンドウタイトルを指定してリサイズ
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    // Finder のウィンドウタイトルは通常フォルダ名
+    // "Desktop" や "Documents" などを含む可能性がある
+    let result = resize_window("Finder", Some(""), Some((300, 300)), Some((700, 500)));
+
+    // タイトルが見つからない場合は最初のウィンドウを使用
+    // エラーが返される可能性もある
+    if result.is_ok() {
+        let resize_result = result.unwrap();
+        assert_eq!(resize_result.status, "success");
+    }
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_nonexistent_app() {
+    // 存在しないアプリケーションでテスト
+    let result = resize_window(
+        "NonExistentApp123456",
+        None,
+        Some((100, 100)),
+        Some((800, 600)),
+    );
+
+    // エラーが返されることを期待
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_boundary_zero_position() {
+    // 位置が (0, 0) の場合（境界値テスト）
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((0, 0)), Some((800, 600)));
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.new_position, Some((0, 0)));
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_boundary_small_size() {
+    // 小さいサイズの場合（境界値テスト）
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((100, 100)), Some((200, 150)));
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.new_size, Some((200, 150)));
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_boundary_large_size() {
+    // 非常に大きいサイズの場合（境界値テスト）
+    // 注: ディスプレイより大きいサイズを指定
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((0, 0)), Some((5000, 3000)));
+
+    // macOS がサイズを制限する可能性があるが、コマンド自体は成功する可能性がある
+    if result.is_ok() {
+        let resize_result = result.unwrap();
+        assert_eq!(resize_result.new_size, Some((5000, 3000)));
+    }
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_negative_position() {
+    // 負の座標（画面外）
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((-100, -100)), Some((800, 600)));
+
+    // macOS は負の座標を許可する可能性がある（マルチディスプレイ環境）
+    // エラーになるかもしれないし、成功するかもしれない
+    // ここでは結果のみを確認
+    if result.is_ok() {
+        let resize_result = result.unwrap();
+        assert_eq!(resize_result.new_position, Some((-100, -100)));
+    }
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_special_chars_in_app_name() {
+    // 特殊文字を含むアプリケーション名
+    let result = resize_window(
+        "App\"With\\Special\nChars",
+        None,
+        Some((100, 100)),
+        Some((800, 600)),
+    );
+
+    // 存在しないアプリケーションなのでエラーが返される
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_special_chars_in_title() {
+    // 特殊文字を含むウィンドウタイトル
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window(
+        "Finder",
+        Some("Title\"With\\Special\nChars"),
+        Some((100, 100)),
+        Some((800, 600)),
+    );
+
+    // タイトルが見つからない場合はエラー
+    // または最初のウィンドウを使用する可能性もある
+    // ここでは結果のみを確認
+    let _ = result;
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_to_json() {
+    // JSON 変換のテスト
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Finder", None, Some((150, 150)), Some((850, 650)));
+
+    if result.is_ok() {
+        let resize_result = result.unwrap();
+        let json = resize_result.to_json();
+
+        assert_eq!(json["status"], "success");
+        assert!(json.get("message").is_some());
+        assert_eq!(json["new_position"]["x"], 150);
+        assert_eq!(json["new_position"]["y"], 150);
+        assert_eq!(json["new_size"]["width"], 850);
+        assert_eq!(json["new_size"]["height"], 650);
+    }
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_unicode_app_name() {
+    // Unicode を含むアプリケーション名
+    let result = resize_window(
+        "日本語アプリ",
+        None,
+        Some((100, 100)),
+        Some((800, 600)),
+    );
+
+    // 存在しないアプリケーションなのでエラーが返される
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_unicode_title() {
+    // Unicode を含むウィンドウタイトル
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window(
+        "Finder",
+        Some("日本語タイトル"),
+        Some((100, 100)),
+        Some((800, 600)),
+    );
+
+    // タイトルが見つからない場合は最初のウィンドウまたはエラー
+    let _ = result;
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_empty_app_name() {
+    // 空文字列のアプリケーション名（境界値テスト）
+    let result = resize_window("", None, Some((100, 100)), Some((800, 600)));
+
+    // エラーが返されることを期待
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_calculator() {
+    // Calculator アプリケーションでテスト
+    let launch_result = launch_or_activate_app("Calculator", 3000);
+    assert!(launch_result.is_ok());
+
+    let result = resize_window("Calculator", None, Some((400, 400)), Some((300, 400)));
+
+    assert!(result.is_ok());
+    let resize_result = result.unwrap();
+    assert_eq!(resize_result.status, "success");
+}
+
+#[test]
+#[ignore]
+fn test_resize_window_multiple_operations() {
+    // 複数回のリサイズ操作
+    let launch_result = launch_or_activate_app("Finder", 3000);
+    assert!(launch_result.is_ok());
+
+    // 1回目のリサイズ
+    let result1 = resize_window("Finder", None, Some((100, 100)), Some((800, 600)));
+    assert!(result1.is_ok());
+
+    // 2回目のリサイズ
+    let result2 = resize_window("Finder", None, Some((200, 200)), Some((900, 700)));
+    assert!(result2.is_ok());
+
+    // 3回目のリサイズ
+    let result3 = resize_window("Finder", None, Some((300, 300)), Some((1000, 800)));
+    assert!(result3.is_ok());
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,0 +1,662 @@
+use apptidying::config::{parse_position_value, parse_size_value};
+use serde_json::json;
+
+// =============================================================================
+// parse_position_value() Tests
+// =============================================================================
+
+#[test]
+fn test_parse_position_left_top() {
+    let position = json!({
+        "x": "left",
+        "y": "top"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 0);
+    assert_eq!(y, 25); // top = menu bar height
+}
+
+#[test]
+fn test_parse_position_right_bottom() {
+    let position = json!({
+        "x": "right",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1920 - 800); // display_width - window_width
+    assert_eq!(y, 1080 - 600); // display_height - window_height
+}
+
+#[test]
+fn test_parse_position_left_bottom() {
+    let position = json!({
+        "x": "left",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 0);
+    assert_eq!(y, 1080 - 600);
+}
+
+#[test]
+fn test_parse_position_right_top() {
+    let position = json!({
+        "x": "right",
+        "y": "top"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1920 - 800);
+    assert_eq!(y, 25);
+}
+
+#[test]
+fn test_parse_position_absolute_coordinates() {
+    let position = json!({
+        "x": 100,
+        "y": 200
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 100);
+    assert_eq!(y, 200);
+}
+
+#[test]
+fn test_parse_position_mixed_pattern_and_number() {
+    let position = json!({
+        "x": "left",
+        "y": 300
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 0);
+    assert_eq!(y, 300);
+}
+
+#[test]
+fn test_parse_position_boundary_zero() {
+    let position = json!({
+        "x": 0,
+        "y": 0
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 0);
+    assert_eq!(y, 0);
+}
+
+#[test]
+fn test_parse_position_boundary_max() {
+    let position = json!({
+        "x": 1920,
+        "y": 1080
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1920);
+    assert_eq!(y, 1080);
+}
+
+#[test]
+fn test_parse_position_window_larger_than_display() {
+    // window_width > display_width の場合でも計算可能
+    let position = json!({
+        "x": "right",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 2500, 1500, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1920 - 2500); // 負の値になる
+    assert_eq!(y, 1080 - 1500);
+}
+
+#[test]
+fn test_parse_position_invalid_x_pattern() {
+    let position = json!({
+        "x": "center",
+        "y": "top"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("無効な x 値"));
+}
+
+#[test]
+fn test_parse_position_invalid_y_pattern() {
+    let position = json!({
+        "x": "left",
+        "y": "middle"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("無効な y 値"));
+}
+
+#[test]
+fn test_parse_position_negative_x() {
+    let position = json!({
+        "x": -100,
+        "y": 200
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("x が負です"));
+}
+
+#[test]
+fn test_parse_position_negative_y() {
+    let position = json!({
+        "x": 100,
+        "y": -200
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("y が負です"));
+}
+
+#[test]
+fn test_parse_position_missing_x_field() {
+    let position = json!({
+        "y": "top"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("x フィールドが見つかりません"));
+}
+
+#[test]
+fn test_parse_position_missing_y_field() {
+    let position = json!({
+        "x": "left"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("y フィールドが見つかりません"));
+}
+
+#[test]
+fn test_parse_position_not_object() {
+    let position = json!("not an object");
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("オブジェクトである必要があります"));
+}
+
+#[test]
+fn test_parse_position_x_invalid_type() {
+    let position = json!({
+        "x": true,
+        "y": "top"
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("文字列または数値である必要があります"));
+}
+
+#[test]
+fn test_parse_position_y_invalid_type() {
+    let position = json!({
+        "x": "left",
+        "y": []
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("文字列または数値である必要があります"));
+}
+
+#[test]
+fn test_parse_position_float_coordinates() {
+    // 浮動小数点数の扱い (整数として扱われない)
+    let position = json!({
+        "x": 100.5,
+        "y": 200.7
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("整数である必要があります"));
+}
+
+// =============================================================================
+// parse_size_value() Tests
+// =============================================================================
+
+#[test]
+fn test_parse_size_half_half() {
+    let size = json!({
+        "width": "half",
+        "height": "half"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920 / 2);
+    assert_eq!(height, 1080 / 2);
+}
+
+#[test]
+fn test_parse_size_third_third() {
+    let size = json!({
+        "width": "third",
+        "height": "third"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920 / 3);
+    assert_eq!(height, 1080 / 3);
+}
+
+#[test]
+fn test_parse_size_max_max() {
+    let size = json!({
+        "width": "max",
+        "height": "max"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920);
+    assert_eq!(height, 1080);
+}
+
+#[test]
+fn test_parse_size_mixed_pattern() {
+    let size = json!({
+        "width": "half",
+        "height": "max"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920 / 2);
+    assert_eq!(height, 1080);
+}
+
+#[test]
+fn test_parse_size_absolute_values() {
+    let size = json!({
+        "width": 1440,
+        "height": 900
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1440);
+    assert_eq!(height, 900);
+}
+
+#[test]
+fn test_parse_size_mixed_pattern_and_number() {
+    let size = json!({
+        "width": "half",
+        "height": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920 / 2);
+    assert_eq!(height, 500);
+}
+
+#[test]
+fn test_parse_size_boundary_min() {
+    let size = json!({
+        "width": 1,
+        "height": 1
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1);
+    assert_eq!(height, 1);
+}
+
+#[test]
+fn test_parse_size_boundary_max() {
+    let size = json!({
+        "width": 3840,
+        "height": 2160
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 3840);
+    assert_eq!(height, 2160);
+}
+
+#[test]
+fn test_parse_size_larger_than_display() {
+    // ディスプレイより大きいサイズでも計算は可能（後でバリデーション）
+    let size = json!({
+        "width": 5000,
+        "height": 3000
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 5000);
+    assert_eq!(height, 3000);
+}
+
+#[test]
+fn test_parse_size_invalid_width_pattern() {
+    let size = json!({
+        "width": "quarter",
+        "height": "half"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("無効な width 値"));
+}
+
+#[test]
+fn test_parse_size_invalid_height_pattern() {
+    let size = json!({
+        "width": "half",
+        "height": "quarter"
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("無効な height 値"));
+}
+
+#[test]
+fn test_parse_size_zero_width() {
+    let size = json!({
+        "width": 0,
+        "height": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("正の値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_zero_height() {
+    let size = json!({
+        "width": 500,
+        "height": 0
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("正の値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_negative_width() {
+    let size = json!({
+        "width": -100,
+        "height": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("正の値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_negative_height() {
+    let size = json!({
+        "width": 500,
+        "height": -100
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("正の値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_missing_width_field() {
+    let size = json!({
+        "height": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("width フィールドが見つかりません"));
+}
+
+#[test]
+fn test_parse_size_missing_height_field() {
+    let size = json!({
+        "width": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("height フィールドが見つかりません"));
+}
+
+#[test]
+fn test_parse_size_not_object() {
+    let size = json!("not an object");
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("オブジェクトである必要があります"));
+}
+
+#[test]
+fn test_parse_size_width_invalid_type() {
+    let size = json!({
+        "width": true,
+        "height": 500
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("文字列または数値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_height_invalid_type() {
+    let size = json!({
+        "width": 500,
+        "height": []
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("文字列または数値である必要があります"));
+}
+
+#[test]
+fn test_parse_size_float_values() {
+    // 浮動小数点数の扱い
+    let size = json!({
+        "width": 100.5,
+        "height": 200.7
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.message.contains("整数である必要があります"));
+}
+
+// =============================================================================
+// Edge Cases and Boundary Value Tests
+// =============================================================================
+
+#[test]
+fn test_parse_position_very_large_coordinates() {
+    let position = json!({
+        "x": 100000,
+        "y": 100000
+    });
+
+    let result = parse_position_value(&position, 1920, 1080, 800, 600, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 100000);
+    assert_eq!(y, 100000);
+}
+
+#[test]
+fn test_parse_size_very_large_values() {
+    let size = json!({
+        "width": 100000,
+        "height": 100000
+    });
+
+    let result = parse_size_value(&size, 1920, 1080, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 100000);
+    assert_eq!(height, 100000);
+}
+
+#[test]
+fn test_parse_position_small_display() {
+    // 小さいディスプレイでの動作
+    let position = json!({
+        "x": "right",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 800, 600, 400, 300, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 400);
+    assert_eq!(y, 300);
+}
+
+#[test]
+fn test_parse_size_small_display() {
+    let size = json!({
+        "width": "half",
+        "height": "third"
+    });
+
+    let result = parse_size_value(&size, 800, 600, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 400);
+    assert_eq!(height, 200);
+}
+
+#[test]
+fn test_parse_position_4k_display() {
+    // 4Kディスプレイでの動作
+    let position = json!({
+        "x": "right",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 3840, 2160, 1920, 1080, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1920);
+    assert_eq!(y, 1080);
+}
+
+#[test]
+fn test_parse_size_4k_display() {
+    let size = json!({
+        "width": "half",
+        "height": "half"
+    });
+
+    let result = parse_size_value(&size, 3840, 2160, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1920);
+    assert_eq!(height, 1080);
+}
+
+#[test]
+fn test_parse_position_odd_display_dimensions() {
+    // 奇数サイズのディスプレイ
+    let position = json!({
+        "x": "right",
+        "y": "bottom"
+    });
+
+    let result = parse_position_value(&position, 1921, 1081, 801, 601, "position");
+    assert!(result.is_ok());
+    let (x, y) = result.unwrap();
+    assert_eq!(x, 1120);
+    assert_eq!(y, 480);
+}
+
+#[test]
+fn test_parse_size_odd_display_dimensions() {
+    // 奇数サイズでの half, third の計算
+    let size = json!({
+        "width": "half",
+        "height": "third"
+    });
+
+    let result = parse_size_value(&size, 1921, 1081, "size");
+    assert!(result.is_ok());
+    let (width, height) = result.unwrap();
+    assert_eq!(width, 1921 / 2); // 整数除算
+    assert_eq!(height, 1081 / 3);
+}


### PR DESCRIPTION
## 概要

AppleScript でウィンドウの位置・サイズ変更機能を実装しました。

## 実装内容

### applescript.rs の拡張

#### DisplayInfo / DisplayError 構造体
- ディスプレイ情報（名前、幅、高さ、原点座標）を管理
- JSON 変換機能付き

#### get_display_info() 関数
- JXA でディスプレイ情報を取得
- メインディスプレイまたは指定名のディスプレイを取得
- 存在しない場合は メインディスプレイにフォールバック

#### WindowResizeResult / WindowResizeError 構造体
- リサイズ結果（status, message, new_position, new_size）を管理
- JSON 変換機能付き

#### resize_window() 関数
- ウィンドウの位置とサイズを変更
- タイトル指定による検索に対応
- AppleScript でウィンドウを操作

### config.rs の拡張

#### parse_position_value() 関数
- パターン指定: "left", "right", "top", "bottom"
- メニューバー高さを 25px と仮定
- 絶対座標（数値）にも対応
- 境界値チェック付き

#### parse_size_value() 関数
- パターン指定: "half", "third", "max"
- 絶対サイズ（数値）にも対応
- サイズバリデーション付き

#### Helper 関数群
- parse_x_value(), parse_y_value()
- parse_width_value(), parse_height_value()

## テスト実装

### ユニットテスト (tests/config_test.rs - 新規)
- 48 個のテストケース
- パターン計算の正常系・異常系をカバー
- 境界値テスト（0, 負の値、最大値）
- エラーハンドリング検証
- **テスト結果: 48/48 パス**

### 統合テスト (tests/applescript_test.rs - 拡張)
- DisplayInfo と get_display_info() のテスト
- resize_window() のテスト
- osascript 実行に依存するテストは #[ignore] で除外
- **テスト結果: 77/77 パス (非ignore)**

## テスト結果サマリー

```
合計: 125 テストパス
- config_test.rs: 48
- applescript_test.rs (非 #[ignore]): 77
- #[ignore] テスト: 41 (osascript 実行のため)
```

## コミット情報

- Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)