### PR TITLE
fix: JXAスクリプトの引数参照エラー修正

### DIFF
--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -265,76 +265,81 @@ impl std::error::Error for DisplayError {}
 #[allow(dead_code)]
 pub fn get_display_info(display_name: Option<&str>) -> Result<DisplayInfo, DisplayError> {
     // Get all displays using JXA
-    let jxa_script = r#"
+    let search_name_value = if display_name.is_none() || display_name == Some("") {
+        "null".to_string()
+    } else {
+        format!("\"{}\"", display_name.unwrap().replace("\"", "\\\""))
+    };
+
+    let jxa_script = format!(
+        r#"
 ObjC.import('AppKit')
 
 const screens = $.NSScreen.screens
 let targetDisplay = null
 
-if (screens.count === 0) {
+if (screens.count === 0) {{
     "error: no displays found"
-} else {
-    let searchName = null
-    if (ObjC.unwrap(arguments[0]) !== null) {
-        searchName = ObjC.unwrap(arguments[0])
-    }
+}} else {{
+    let searchName = {}
 
-    for (let i = 0; i < screens.count; i++) {
+    for (let i = 0; i < screens.count; i++) {{
         const screen = screens.objectAtIndex(i)
         const displayName = ObjC.unwrap(screen.localizedName) || "Unknown"
 
-        if (searchName === null || displayName === searchName) {
+        if (searchName === null || displayName === searchName) {{
             const frame = screen.frame
-            const result = {
+            const result = {{
                 name: displayName,
                 width: Math.round(frame.size.width),
                 height: Math.round(frame.size.height),
                 origin_x: Math.round(frame.origin.x),
                 origin_y: Math.round(frame.origin.y)
-            }
+            }}
             targetDisplay = result
             break
-        }
-    }
+        }}
+    }}
 
-    if (targetDisplay === null && searchName !== null) {
+    if (targetDisplay === null && searchName !== null) {{
         // Display with specified name not found, use main display
         const mainScreen = $.NSScreen.mainScreen
         const displayName = ObjC.unwrap(mainScreen.localizedName) || "Main"
         const frame = mainScreen.frame
-        const result = {
+        const result = {{
             name: displayName,
             width: Math.round(frame.size.width),
             height: Math.round(frame.size.height),
             origin_x: Math.round(frame.origin.x),
             origin_y: Math.round(frame.origin.y)
-        }
+        }}
         targetDisplay = result
-    } else if (targetDisplay === null) {
+    }} else if (targetDisplay === null) {{
         // Use main display if no specific name requested
         const mainScreen = $.NSScreen.mainScreen
         const displayName = ObjC.unwrap(mainScreen.localizedName) || "Main"
         const frame = mainScreen.frame
-        const result = {
+        const result = {{
             name: displayName,
             width: Math.round(frame.size.width),
             height: Math.round(frame.size.height),
             origin_x: Math.round(frame.origin.x),
             origin_y: Math.round(frame.origin.y)
-        }
+        }}
         targetDisplay = result
-    }
+    }}
 
     JSON.stringify(targetDisplay)
-}
-"#;
+}}
+"#,
+        search_name_value
+    );
 
     let output = Command::new("osascript")
         .arg("-l")
         .arg("JavaScript")
         .arg("-e")
         .arg(jxa_script)
-        .arg(display_name.unwrap_or(""))
         .output()
         .map_err(|e| DisplayError {
             message: format!("osascriptの実行に失敗しました: {}", e),

--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -265,10 +265,9 @@ impl std::error::Error for DisplayError {}
 #[allow(dead_code)]
 pub fn get_display_info(display_name: Option<&str>) -> Result<DisplayInfo, DisplayError> {
     // Get all displays using JXA
-    let search_name_value = if display_name.is_none() || display_name == Some("") {
-        "null".to_string()
-    } else {
-        format!("\"{}\"", display_name.unwrap().replace("\"", "\\\""))
+    let search_name_value = match display_name {
+        Some(name) if !name.is_empty() => format!("\"{}\"", name.replace("\"", "\\\"")),
+        _ => "null".to_string(),
     };
 
     let jxa_script = format!(


### PR DESCRIPTION
## 概要

`get_display_info` 関数のJXAスクリプト内で不正な `arguments[0]` 参照を修正しました。

## 問題

- JXAスクリプト内で `arguments[0]` を参照していた
- JXAではコマンドラインの引数が `arguments` 配列として自動的に利用できない
- テスト `test_get_display_info_main_display` が「Can't find variable: arguments」エラーで失敗

## 修正内容

1. Rust側で `display_name` パラメータから `search_name_value` を計算
   - 空の場合は `"null"`
   - それ以外は `"\"display_name\""` 形式

2. JXAスクリプトを `format!` で生成
   - `search_name_value` を直接埋め込む

3. osascriptのコマンドライン引数を削除
   - `.arg(display_name...)` を削除

## テスト結果

- ✅ test_get_display_info_main_display: PASS
- ✅ 全テスト: 70 passed; 0 failed; 8 ignored
- ✅ cargo fmt: OK
- ✅ cargo clippy: OK

## 関連PR

#56 (P2-1-3: ウィンドウ情報取得スクリプト実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)