### PR TITLE
feat: P2-2-3: システムウィンドウ判定機能実装

### DIFF
--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -887,6 +887,119 @@ pub fn parse_window_list(result_str: &str) -> Result<Vec<WindowInfo>, WindowInfo
     Ok(windows)
 }
 
+// =============================================================================
+// System Window Detection
+// =============================================================================
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub enum WindowType {
+    /// Regular application window that can be managed
+    Regular,
+    /// System window that should be excluded (menu bar, dock, etc.)
+    System,
+}
+
+/// Check if an application is a system application (Finder, Mail, Safari, etc.)
+#[allow(dead_code)]
+pub fn is_system_app(app_name: &str) -> bool {
+    // System applications that are part of macOS and should be manageable
+    let system_apps = vec![
+        "Finder",
+        "Mail",
+        "Safari",
+        "Calendar",
+        "Notes",
+        "Maps",
+        "Messages",
+        "Contacts",
+        "Reminders",
+        "Stocks",
+        "Weather",
+        "Podcasts",
+        "News",
+        "Home",
+        "Music",
+        "TV",
+        "Books",
+        "Dictionary",
+        "Thesaurus",
+        "Migration Assistant",
+        "Photo Booth",
+        "Preview",
+        "TextEdit",
+        "System Preferences",
+        "System Settings",
+        "Disk Utility",
+        "Terminal",
+        "Console",
+        "Activity Monitor",
+        "Bluetooth Screen Lock",
+        "App Store",
+        "iBooks",
+        "Keynote",
+        "Numbers",
+        "Pages",
+        "FileMerge",
+        "Xcode",
+    ];
+
+    system_apps.contains(&app_name)
+}
+
+/// Check if a window should be excluded from management
+/// (returns true if the window is a system UI element that should be excluded)
+#[allow(dead_code)]
+pub fn is_excluded_window(app_name: &str, window_title: &str) -> bool {
+    // Exclude system UI processes
+    const EXCLUDED_APPS: &[&str] = &[
+        "Dock",
+        "Menubar",
+        "WindowManager",
+        "LoginWindow",
+        "SystemUIServer",
+        "ControlCenter",
+        "NotificationCenter",
+        "Spotlight",
+        "Finder Sync UI",
+        "Quick Look",
+        "Accessibility Inspector",
+    ];
+
+    if EXCLUDED_APPS.contains(&app_name) {
+        return true;
+    }
+
+    // Exclude specific window titles that are system UI elements
+    const EXCLUDED_TITLES: &[&str] = &[
+        "Menu",
+        "Dock",
+        "Notification",
+        "Spotlight",
+        "Control Center",
+        "Accessibility Inspector",
+    ];
+
+    if EXCLUDED_TITLES
+        .iter()
+        .any(|&title| window_title.contains(title))
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Classify a window type based on application name and window properties
+#[allow(dead_code)]
+pub fn classify_window(app_name: &str, window_title: &str) -> WindowType {
+    if is_excluded_window(app_name, window_title) {
+        WindowType::System
+    } else {
+        WindowType::Regular
+    }
+}
+
 /// Get all windows for a specific application
 #[allow(dead_code)]
 pub fn get_all_windows(app_name: &str) -> Result<Vec<WindowInfo>, WindowInfoError> {

--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -901,10 +901,33 @@ pub enum WindowType {
 }
 
 /// Check if an application is a system application (Finder, Mail, Safari, etc.)
+///
+/// # Arguments
+/// * `app_name` - The name of the application to check
+///
+/// # Returns
+/// * `true` if the application is a macOS system application
+/// * `false` otherwise
+///
+/// # System Apps List
+/// This function recognizes 37 macOS system applications including:
+/// - Core apps: Finder, Mail, Safari, Calendar, Notes, Maps, Messages, Contacts
+/// - Utilities: Disk Utility, Terminal, Console, Activity Monitor
+/// - Media: Music, TV, News, Podcasts, Weather, Stocks, Home
+/// - iWork: Keynote, Numbers, Pages
+/// - Development: Xcode
+///
+/// # Examples
+/// ```
+/// assert!(is_system_app("Finder"));
+/// assert!(is_system_app("Mail"));
+/// assert!(is_system_app("Safari"));
+/// assert!(!is_system_app("Google Chrome"));
+/// assert!(!is_system_app("Visual Studio Code"));
+/// ```
 #[allow(dead_code)]
 pub fn is_system_app(app_name: &str) -> bool {
-    // System applications that are part of macOS and should be manageable
-    let system_apps = vec![
+    const SYSTEM_APPS: &[&str] = &[
         "Finder",
         "Mail",
         "Safari",
@@ -944,15 +967,40 @@ pub fn is_system_app(app_name: &str) -> bool {
         "Xcode",
     ];
 
-    system_apps.contains(&app_name)
+    SYSTEM_APPS.contains(&app_name)
 }
 
 /// Check if a window should be excluded from management
-/// (returns true if the window is a system UI element that should be excluded)
+///
+/// Returns `true` if the window is a system UI element that should not be managed.
+/// Checks both the application name and window title against known exclusion patterns.
+///
+/// # Arguments
+/// * `app_name` - The name of the application
+/// * `window_title` - The title of the window
+///
+/// # Returns
+/// * `true` if the window is a system UI element that should be excluded
+/// * `false` if the window can be managed
+///
+/// # Excluded Applications
+/// - Dock, Menubar, WindowManager, LoginWindow, SystemUIServer
+/// - ControlCenter, NotificationCenter, Spotlight
+/// - Finder Sync UI, Quick Look, Accessibility Inspector
+///
+/// # Excluded Window Title Patterns
+/// - Titles containing: "Menu", "Dock", "Notification", "Spotlight", "Control Center", "Accessibility Inspector"
+///
+/// # Examples
+/// ```
+/// assert!(is_excluded_window("Dock", ""));
+/// assert!(is_excluded_window("Finder", "Menu"));
+/// assert!(!is_excluded_window("Finder", "Documents"));
+/// ```
 #[allow(dead_code)]
 pub fn is_excluded_window(app_name: &str, window_title: &str) -> bool {
     // Exclude system UI processes
-    const EXCLUDED_APPS: &[&str] = &[
+    const EXCLUDED_APP_NAMES: &[&str] = &[
         "Dock",
         "Menubar",
         "WindowManager",
@@ -966,12 +1014,12 @@ pub fn is_excluded_window(app_name: &str, window_title: &str) -> bool {
         "Accessibility Inspector",
     ];
 
-    if EXCLUDED_APPS.contains(&app_name) {
+    if EXCLUDED_APP_NAMES.contains(&app_name) {
         return true;
     }
 
     // Exclude specific window titles that are system UI elements
-    const EXCLUDED_TITLES: &[&str] = &[
+    const EXCLUDED_WINDOW_TITLE_PATTERNS: &[&str] = &[
         "Menu",
         "Dock",
         "Notification",
@@ -980,9 +1028,9 @@ pub fn is_excluded_window(app_name: &str, window_title: &str) -> bool {
         "Accessibility Inspector",
     ];
 
-    if EXCLUDED_TITLES
+    if EXCLUDED_WINDOW_TITLE_PATTERNS
         .iter()
-        .any(|&title| window_title.contains(title))
+        .any(|&pattern| window_title.contains(pattern))
     {
         return true;
     }
@@ -991,6 +1039,31 @@ pub fn is_excluded_window(app_name: &str, window_title: &str) -> bool {
 }
 
 /// Classify a window type based on application name and window properties
+///
+/// Determines whether a window should be managed or excluded based on its
+/// application and title. This is a convenience function that wraps
+/// `is_excluded_window()` and returns the appropriate `WindowType`.
+///
+/// # Arguments
+/// * `app_name` - The name of the application
+/// * `window_title` - The title of the window
+///
+/// # Returns
+/// * `WindowType::System` if the window should be excluded from management
+/// * `WindowType::Regular` if the window can be managed
+///
+/// # Examples
+/// ```
+/// use apptidying::applescript::{classify_window, WindowType};
+///
+/// // Regular manageable window
+/// let result = classify_window("Finder", "Documents");
+/// assert!(matches!(result, WindowType::Regular));
+///
+/// // System window that should be excluded
+/// let result = classify_window("Dock", "");
+/// assert!(matches!(result, WindowType::System));
+/// ```
 #[allow(dead_code)]
 pub fn classify_window(app_name: &str, window_title: &str) -> WindowType {
     if is_excluded_window(app_name, window_title) {

--- a/src/applescript.rs
+++ b/src/applescript.rs
@@ -919,6 +919,8 @@ pub enum WindowType {
 ///
 /// # Examples
 /// ```
+/// use apptidying::applescript::is_system_app;
+///
 /// assert!(is_system_app("Finder"));
 /// assert!(is_system_app("Mail"));
 /// assert!(is_system_app("Safari"));
@@ -993,6 +995,8 @@ pub fn is_system_app(app_name: &str) -> bool {
 ///
 /// # Examples
 /// ```
+/// use apptidying::applescript::is_excluded_window;
+///
 /// assert!(is_excluded_window("Dock", ""));
 /// assert!(is_excluded_window("Finder", "Menu"));
 /// assert!(!is_excluded_window("Finder", "Documents"));

--- a/tests/system_window_detection_test.rs
+++ b/tests/system_window_detection_test.rs
@@ -1,0 +1,940 @@
+//! Unit tests for system window detection functions
+//!
+//! This test suite provides comprehensive coverage of the window classification
+//! functionality, including:
+//! - is_system_app: Checks if an app is a macOS system application
+//! - is_excluded_window: Checks if a window should be excluded from management
+//! - classify_window: Classifies a window as Regular or System
+//!
+//! Testing strategy:
+//! - Black box testing: Equivalent partitioning, boundary value analysis
+//! - White box testing: Branch coverage, statement coverage
+
+use apptidying::applescript::{classify_window, is_excluded_window, is_system_app, WindowType};
+
+// =============================================================================
+// Tests for is_system_app
+// =============================================================================
+
+#[cfg(test)]
+mod test_is_system_app {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Valid System Apps
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_finder_is_system_app() {
+        // Finder is a core macOS system application
+        assert!(
+            is_system_app("Finder"),
+            "Finder should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_mail_is_system_app() {
+        assert!(
+            is_system_app("Mail"),
+            "Mail should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_safari_is_system_app() {
+        assert!(
+            is_system_app("Safari"),
+            "Safari should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_terminal_is_system_app() {
+        assert!(
+            is_system_app("Terminal"),
+            "Terminal should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_system_preferences_is_system_app() {
+        assert!(
+            is_system_app("System Preferences"),
+            "System Preferences should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_system_settings_is_system_app() {
+        // macOS Ventura and later use "System Settings" instead of "System Preferences"
+        assert!(
+            is_system_app("System Settings"),
+            "System Settings should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_xcode_is_system_app() {
+        assert!(
+            is_system_app("Xcode"),
+            "Xcode should be recognized as a system app"
+        );
+    }
+
+    #[test]
+    fn test_all_documented_system_apps() {
+        // Comprehensive test of all system apps mentioned in the implementation
+        let system_apps = vec![
+            "Finder",
+            "Mail",
+            "Safari",
+            "Calendar",
+            "Notes",
+            "Maps",
+            "Messages",
+            "Contacts",
+            "Reminders",
+            "Stocks",
+            "Weather",
+            "Podcasts",
+            "News",
+            "Home",
+            "Music",
+            "TV",
+            "Books",
+            "Dictionary",
+            "Thesaurus",
+            "Migration Assistant",
+            "Photo Booth",
+            "Preview",
+            "TextEdit",
+            "System Preferences",
+            "System Settings",
+            "Disk Utility",
+            "Terminal",
+            "Console",
+            "Activity Monitor",
+            "Bluetooth Screen Lock",
+            "App Store",
+            "iBooks",
+            "Keynote",
+            "Numbers",
+            "Pages",
+            "FileMerge",
+            "Xcode",
+        ];
+
+        for app in system_apps {
+            assert!(
+                is_system_app(app),
+                "{} should be recognized as a system app",
+                app
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Non-System Apps
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_chrome_is_not_system_app() {
+        assert!(
+            !is_system_app("Google Chrome"),
+            "Google Chrome should not be a system app"
+        );
+    }
+
+    #[test]
+    fn test_vscode_is_not_system_app() {
+        assert!(
+            !is_system_app("Visual Studio Code"),
+            "Visual Studio Code should not be a system app"
+        );
+    }
+
+    #[test]
+    fn test_slack_is_not_system_app() {
+        assert!(!is_system_app("Slack"), "Slack should not be a system app");
+    }
+
+    #[test]
+    fn test_custom_app_is_not_system_app() {
+        assert!(
+            !is_system_app("MyCustomApp"),
+            "MyCustomApp should not be a system app"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Boundary Value Analysis: Edge Cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_string_is_not_system_app() {
+        // Empty string should not match any system app
+        assert!(
+            !is_system_app(""),
+            "Empty string should not be a system app"
+        );
+    }
+
+    #[test]
+    fn test_case_sensitivity_lowercase() {
+        // The implementation uses exact string matching, so case matters
+        assert!(
+            !is_system_app("finder"),
+            "Case should be sensitive: 'finder' != 'Finder'"
+        );
+    }
+
+    #[test]
+    fn test_case_sensitivity_uppercase() {
+        assert!(
+            !is_system_app("FINDER"),
+            "Case should be sensitive: 'FINDER' != 'Finder'"
+        );
+    }
+
+    #[test]
+    fn test_partial_match_does_not_work() {
+        // "Find" is a substring of "Finder" but should not match
+        assert!(
+            !is_system_app("Find"),
+            "Partial match should not work for system apps"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_prefix() {
+        // Leading whitespace should prevent matching
+        assert!(
+            !is_system_app(" Finder"),
+            "Leading whitespace should prevent match"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_suffix() {
+        // Trailing whitespace should prevent matching
+        assert!(
+            !is_system_app("Finder "),
+            "Trailing whitespace should prevent match"
+        );
+    }
+
+    #[test]
+    fn test_special_characters_in_name() {
+        // App names with special characters should not match system apps
+        assert!(
+            !is_system_app("Finder@123"),
+            "App with special characters should not match"
+        );
+        assert!(
+            !is_system_app("Mail.app"),
+            "App with .app extension should not match"
+        );
+    }
+
+    #[test]
+    fn test_unicode_characters() {
+        // Unicode characters should not match
+        assert!(
+            !is_system_app("Finder™"),
+            "Unicode characters should prevent match"
+        );
+    }
+}
+
+// =============================================================================
+// Tests for is_excluded_window
+// =============================================================================
+
+#[cfg(test)]
+mod test_is_excluded_window {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Excluded Apps
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_dock_app_is_excluded() {
+        assert!(
+            is_excluded_window("Dock", ""),
+            "Dock app should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_menubar_app_is_excluded() {
+        assert!(
+            is_excluded_window("Menubar", ""),
+            "Menubar app should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_systemuiserver_is_excluded() {
+        assert!(
+            is_excluded_window("SystemUIServer", ""),
+            "SystemUIServer should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_control_center_app_is_excluded() {
+        assert!(
+            is_excluded_window("ControlCenter", ""),
+            "ControlCenter app should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_notification_center_app_is_excluded() {
+        assert!(
+            is_excluded_window("NotificationCenter", ""),
+            "NotificationCenter app should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_spotlight_app_is_excluded() {
+        assert!(
+            is_excluded_window("Spotlight", ""),
+            "Spotlight app should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_all_documented_excluded_apps() {
+        // Test all apps from EXCLUDED_APPS constant
+        let excluded_apps = vec![
+            "Dock",
+            "Menubar",
+            "WindowManager",
+            "LoginWindow",
+            "SystemUIServer",
+            "ControlCenter",
+            "NotificationCenter",
+            "Spotlight",
+            "Finder Sync UI",
+            "Quick Look",
+            "Accessibility Inspector",
+        ];
+
+        for app in excluded_apps {
+            assert!(
+                is_excluded_window(app, ""),
+                "{} should be excluded",
+                app
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Excluded Window Titles
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_menu_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Menu"),
+            "Window with 'Menu' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_dock_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Dock"),
+            "Window with 'Dock' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_notification_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Notification"),
+            "Window with 'Notification' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_spotlight_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Spotlight"),
+            "Window with 'Spotlight' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_control_center_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Control Center"),
+            "Window with 'Control Center' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_accessibility_inspector_title_is_excluded() {
+        assert!(
+            is_excluded_window("SomeApp", "Accessibility Inspector"),
+            "Window with 'Accessibility Inspector' title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_partial_title_match_menu() {
+        // The implementation uses contains(), so partial matches should work
+        assert!(
+            is_excluded_window("SomeApp", "File Menu"),
+            "Window title containing 'Menu' should be excluded"
+        );
+        assert!(
+            is_excluded_window("SomeApp", "MenuBar Helper"),
+            "Window title containing 'Menu' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_partial_title_match_dock() {
+        assert!(
+            is_excluded_window("SomeApp", "Dock Preferences"),
+            "Window title containing 'Dock' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_partial_title_match_notification() {
+        assert!(
+            is_excluded_window("SomeApp", "Notification Settings"),
+            "Window title containing 'Notification' should be excluded"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Non-Excluded Windows
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_regular_window_is_not_excluded() {
+        assert!(
+            !is_excluded_window("Google Chrome", "Welcome"),
+            "Regular window should not be excluded"
+        );
+    }
+
+    #[test]
+    fn test_finder_window_is_not_excluded() {
+        // Finder is a system app but not an excluded app
+        assert!(
+            !is_excluded_window("Finder", "Documents"),
+            "Finder window should not be excluded"
+        );
+    }
+
+    #[test]
+    fn test_safari_window_is_not_excluded() {
+        assert!(
+            !is_excluded_window("Safari", "Apple"),
+            "Safari window should not be excluded"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Boundary Value Analysis: Edge Cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_app_name_and_title() {
+        assert!(
+            !is_excluded_window("", ""),
+            "Empty app and title should not be excluded"
+        );
+    }
+
+    #[test]
+    fn test_empty_app_name_with_valid_title() {
+        assert!(
+            is_excluded_window("", "Menu"),
+            "Empty app name but excluded title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_valid_app_name_with_empty_title() {
+        assert!(
+            is_excluded_window("Dock", ""),
+            "Excluded app with empty title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_case_sensitivity_in_title() {
+        // The implementation uses contains() which is case-sensitive
+        assert!(
+            !is_excluded_window("SomeApp", "menu"),
+            "Lowercase 'menu' should not match 'Menu'"
+        );
+        assert!(
+            !is_excluded_window("SomeApp", "MENU"),
+            "Uppercase 'MENU' should not match 'Menu'"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_in_title() {
+        assert!(
+            is_excluded_window("SomeApp", " Menu "),
+            "Title with whitespace containing 'Menu' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_special_characters_in_title() {
+        assert!(
+            is_excluded_window("SomeApp", "Menu - Settings"),
+            "Title with special characters containing 'Menu' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_unicode_in_title() {
+        assert!(
+            is_excluded_window("SomeApp", "Menu™"),
+            "Title with unicode containing 'Menu' should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_near_match_title() {
+        // "Men" is close to "Menu" but should not match
+        assert!(
+            !is_excluded_window("SomeApp", "Men"),
+            "Near match should not be excluded"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Branch Coverage: Both Conditions
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_both_app_and_title_match() {
+        // Both app name and title match exclusion criteria
+        // Should return true (short-circuit on app name check)
+        assert!(
+            is_excluded_window("Dock", "Menu"),
+            "Both app and title excluded should return true"
+        );
+    }
+
+    #[test]
+    fn test_app_matches_title_does_not() {
+        // App matches but title doesn't (should still be excluded)
+        assert!(
+            is_excluded_window("Dock", "Regular Window"),
+            "Excluded app should be excluded regardless of title"
+        );
+    }
+
+    #[test]
+    fn test_title_matches_app_does_not() {
+        // Title matches but app doesn't (should be excluded)
+        assert!(
+            is_excluded_window("Google Chrome", "Menu"),
+            "Window with excluded title should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_neither_matches() {
+        // Neither app nor title matches (should not be excluded)
+        assert!(
+            !is_excluded_window("Google Chrome", "Welcome"),
+            "Regular app and title should not be excluded"
+        );
+    }
+}
+
+// =============================================================================
+// Tests for classify_window
+// =============================================================================
+
+#[cfg(test)]
+mod test_classify_window {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: System Windows
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_dock_as_system() {
+        let result = classify_window("Dock", "");
+        assert!(
+            matches!(result, WindowType::System),
+            "Dock should be classified as System"
+        );
+    }
+
+    #[test]
+    fn test_classify_menubar_as_system() {
+        let result = classify_window("Menubar", "");
+        assert!(
+            matches!(result, WindowType::System),
+            "Menubar should be classified as System"
+        );
+    }
+
+    #[test]
+    fn test_classify_window_with_menu_title_as_system() {
+        let result = classify_window("SomeApp", "Menu");
+        assert!(
+            matches!(result, WindowType::System),
+            "Window with 'Menu' title should be classified as System"
+        );
+    }
+
+    #[test]
+    fn test_classify_control_center_as_system() {
+        let result = classify_window("ControlCenter", "Control Center");
+        assert!(
+            matches!(result, WindowType::System),
+            "ControlCenter should be classified as System"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Equivalence Partitioning: Regular Windows
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_chrome_as_regular() {
+        let result = classify_window("Google Chrome", "Welcome");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Google Chrome should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_finder_as_regular() {
+        // Finder is a system app but not an excluded window
+        let result = classify_window("Finder", "Documents");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Finder window should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_safari_as_regular() {
+        let result = classify_window("Safari", "Apple");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Safari should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_terminal_as_regular() {
+        let result = classify_window("Terminal", "bash");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Terminal should be classified as Regular"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Boundary Value Analysis: Edge Cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_empty_strings() {
+        let result = classify_window("", "");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Empty strings should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_whitespace_only() {
+        let result = classify_window("   ", "   ");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Whitespace-only strings should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_special_characters() {
+        let result = classify_window("App@123", "Window#456");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Apps with special characters should be classified as Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_unicode_characters() {
+        let result = classify_window("アプリ", "ウィンドウ");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Apps with unicode should be classified as Regular"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Branch Coverage: All Code Paths
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_excluded_by_app_name() {
+        // Path: is_excluded_window returns true due to app name
+        let result = classify_window("Dock", "Regular Window");
+        assert!(
+            matches!(result, WindowType::System),
+            "Excluded by app name should return System"
+        );
+    }
+
+    #[test]
+    fn test_classify_excluded_by_title() {
+        // Path: is_excluded_window returns true due to title
+        let result = classify_window("Regular App", "Menu");
+        assert!(
+            matches!(result, WindowType::System),
+            "Excluded by title should return System"
+        );
+    }
+
+    #[test]
+    fn test_classify_not_excluded() {
+        // Path: is_excluded_window returns false
+        let result = classify_window("Regular App", "Regular Window");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Not excluded should return Regular"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration Tests: Real-World Scenarios
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_typical_browser_window() {
+        let result = classify_window("Google Chrome", "Stack Overflow - How to test Rust");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Typical browser window should be Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_typical_editor_window() {
+        let result = classify_window("Visual Studio Code", "main.rs - myproject");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Typical editor window should be Regular"
+        );
+    }
+
+    #[test]
+    fn test_classify_system_dialog() {
+        let result = classify_window("SystemUIServer", "Notification");
+        assert!(
+            matches!(result, WindowType::System),
+            "System dialog should be System"
+        );
+    }
+
+    #[test]
+    fn test_classify_finder_main_window() {
+        let result = classify_window("Finder", "Desktop");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Finder main window should be Regular (manageable)"
+        );
+    }
+
+    #[test]
+    fn test_classify_mail_window() {
+        let result = classify_window("Mail", "Inbox");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Mail window should be Regular (manageable)"
+        );
+    }
+}
+
+// =============================================================================
+// Integration Tests: Cross-Function Interactions
+// =============================================================================
+
+#[cfg(test)]
+mod test_integration {
+    use super::*;
+
+    #[test]
+    fn test_system_app_can_have_regular_windows() {
+        // System apps (like Finder) can have regular windows that should be managed
+        assert!(
+            is_system_app("Finder"),
+            "Finder is a system app"
+        );
+        assert!(
+            !is_excluded_window("Finder", "Documents"),
+            "Finder Documents window is not excluded"
+        );
+        let result = classify_window("Finder", "Documents");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Finder Documents should be manageable"
+        );
+    }
+
+    #[test]
+    fn test_non_system_app_cannot_have_system_windows() {
+        // Non-system apps should never have windows classified as System
+        // (unless they have excluded titles, which would be unusual)
+        assert!(
+            !is_system_app("Google Chrome"),
+            "Chrome is not a system app"
+        );
+
+        // Regular window
+        let result = classify_window("Google Chrome", "Welcome");
+        assert!(
+            matches!(result, WindowType::Regular),
+            "Chrome regular window should be Regular"
+        );
+
+        // Even with an excluded title, it should be System (this is edge case)
+        let result = classify_window("Google Chrome", "Menu");
+        assert!(
+            matches!(result, WindowType::System),
+            "Chrome window with excluded title should be System"
+        );
+    }
+
+    #[test]
+    fn test_classification_consistency() {
+        // Verify that classify_window is consistent with is_excluded_window
+        let test_cases = vec![
+            ("Dock", "", true),
+            ("Finder", "Documents", false),
+            ("Safari", "Apple", false),
+            ("SystemUIServer", "", true),
+            ("Google Chrome", "Menu", true),
+            ("Visual Studio Code", "main.rs", false),
+        ];
+
+        for (app, title, should_be_excluded) in test_cases {
+            let is_excluded = is_excluded_window(app, title);
+            let classification = classify_window(app, title);
+
+            assert_eq!(
+                is_excluded, should_be_excluded,
+                "is_excluded_window mismatch for {} - {}",
+                app, title
+            );
+
+            if should_be_excluded {
+                assert!(
+                    matches!(classification, WindowType::System),
+                    "classify_window should return System for {} - {}",
+                    app,
+                    title
+                );
+            } else {
+                assert!(
+                    matches!(classification, WindowType::Regular),
+                    "classify_window should return Regular for {} - {}",
+                    app,
+                    title
+                );
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Code Coverage Report
+// =============================================================================
+
+/*
+Coverage Analysis:
+
+1. is_system_app:
+   - Line coverage: 100%
+     - All system apps in the list tested
+     - Non-system apps tested
+     - Edge cases (empty string, case sensitivity) tested
+   - Branch coverage: 100%
+     - Contains check (true/false) covered
+
+2. is_excluded_window:
+   - Line coverage: 100%
+     - All excluded apps tested
+     - All excluded title patterns tested
+     - Both return paths tested
+   - Branch coverage: 100%
+     - App exclusion check (true/false) covered
+     - Title exclusion check (true/false) covered
+     - All 4 combinations of conditions tested:
+       * Both match
+       * App matches, title doesn't
+       * Title matches, app doesn't
+       * Neither matches
+
+3. classify_window:
+   - Line coverage: 100%
+     - Both WindowType variants returned and tested
+   - Branch coverage: 100%
+     - is_excluded_window true path covered
+     - is_excluded_window false path covered
+
+Overall Coverage:
+- Statement coverage: 100%
+- Branch coverage: 100%
+- Condition coverage: 100%
+- Path coverage: 100%
+
+Test Design Rationale:
+
+Black Box Testing:
+- Equivalent Partitioning: Test cases divided into valid/invalid classes
+  * System apps vs non-system apps
+  * Excluded windows vs regular windows
+- Boundary Value Analysis: Edge cases tested
+  * Empty strings
+  * Case sensitivity
+  * Whitespace handling
+  * Special characters
+  * Unicode characters
+
+White Box Testing:
+- All decision points (if statements) tested with both true and false branches
+- All code paths executed at least once
+- Integration tests verify cross-function consistency
+
+Edge Cases Identified and Tested:
+1. Empty strings for app name and title
+2. Case sensitivity in matching
+3. Whitespace handling (leading, trailing, embedded)
+4. Special characters and unicode
+5. Partial matches in window titles
+6. System apps that have manageable windows (e.g., Finder)
+7. Non-system apps with system-like window titles
+
+Uncovered Code:
+None - all code paths have been tested.
+
+Intentional Gaps:
+None - all functionality has comprehensive test coverage.
+*/

--- a/tests/system_window_detection_test.rs
+++ b/tests/system_window_detection_test.rs
@@ -325,11 +325,7 @@ mod test_is_excluded_window {
         ];
 
         for app in excluded_apps {
-            assert!(
-                is_excluded_window(app, ""),
-                "{} should be excluded",
-                app
-            );
+            assert!(is_excluded_window(app, ""), "{} should be excluded", app);
         }
     }
 
@@ -783,10 +779,7 @@ mod test_integration {
     #[test]
     fn test_system_app_can_have_regular_windows() {
         // System apps (like Finder) can have regular windows that should be managed
-        assert!(
-            is_system_app("Finder"),
-            "Finder is a system app"
-        );
+        assert!(is_system_app("Finder"), "Finder is a system app");
         assert!(
             !is_excluded_window("Finder", "Documents"),
             "Finder Documents window is not excluded"


### PR DESCRIPTION
## Summary

Finderなどのシステムアプリケーションとメニューバー、ドックなどのシステムUIウィンドウを正しく判定する機能を実装しました。

- **Finder、Mail、Safari等のシステムアプリケーション判定**: `is_system_app()` 関数で37個の標準macOSアプリケーションを認識
- **メニューバー、ドック等の対象外ウィンドウ判定**: `is_excluded_window()` 関数でシステムUI要素を除外
- **ウィンドウ分類機能**: `classify_window()` 関数でウィンドウをRegularまたはSystemに分類
- **包括的なテスト**: 74個のユニットテストでコードカバレッジ100%を達成

Closes #60

## Test plan

- ✓ すべてのシステムアプリケーション（37個）が正しく判定される
- ✓ 除外アプリケーション（11個）が正しく除外される
- ✓ 除外ウィンドウタイトル（6パターン）が正しく除外される
- ✓ エッジケース（空文字列、特殊文字、Unicode等）が適切に処理される
- ✓ コードは100% カバレッジでテストされている
- ✓ cargo test で全テスト合格
- ✓ cargo fmt & cargo clippy で警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)