### PR TITLE
feat: P3-4: 設定ファイル互換性・検証の実装

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -140,8 +140,8 @@ pub struct ValidationWarning {
     pub display_name: String,
     /// アプリケーション名
     pub app_name: String,
-    /// 問題の説明
-    pub issue: String,
+    /// 警告メッセージ
+    pub message: String,
 }
 
 #[allow(dead_code)]
@@ -382,13 +382,19 @@ fn validate_display_bounds(
     if let Some(ref position) = window.position {
         // サイズを計算（デフォルトはディスプレイサイズ）
         let window_width = if let Some(ref size) = window.size {
-            calculate_size_for_validation(&size.width, display_info.width)
+            match calculate_size_for_validation(&size.width, display_info.width) {
+                Ok(w) => w,
+                Err(_) => return None, // エラーは構文チェックで処理済み
+            }
         } else {
             display_info.width
         };
 
         let window_height = if let Some(ref size) = window.size {
-            calculate_size_for_validation(&size.height, display_info.height)
+            match calculate_size_for_validation(&size.height, display_info.height) {
+                Ok(h) => h,
+                Err(_) => return None, // エラーは構文チェックで処理済み
+            }
         } else {
             display_info.height
         };
@@ -410,7 +416,7 @@ fn validate_display_bounds(
             return Some(ValidationWarning {
                 display_name: display_name.to_string(),
                 app_name: window.app.clone(),
-                issue: format!(
+                message: format!(
                     "ウィンドウの右端 ({}) がディスプレイの幅 ({}) を超えています",
                     x + window_width,
                     display_info.width
@@ -423,7 +429,7 @@ fn validate_display_bounds(
             return Some(ValidationWarning {
                 display_name: display_name.to_string(),
                 app_name: window.app.clone(),
-                issue: format!(
+                message: format!(
                     "ウィンドウの下端 ({}) がディスプレイの高さ ({}) を超えています",
                     y + window_height,
                     display_info.height
@@ -467,7 +473,7 @@ pub fn validate_config_bounds(
                 warnings.push(ValidationWarning {
                     display_name: display_config.name.clone(),
                     app_name: window.app.clone(),
-                    issue: format!(
+                    message: format!(
                         "ディスプレイ '{}' が接続されていません",
                         display_config.name
                     ),
@@ -517,22 +523,37 @@ pub fn validate_config(
 // =============================================================================
 
 /// サイズ値をピクセル単位で計算（検証用）
-fn calculate_size_for_validation(value: &serde_json::Value, display_size: i32) -> i32 {
+fn calculate_size_for_validation(
+    value: &serde_json::Value,
+    display_size: i32,
+) -> Result<i32, AppConfigError> {
     match value {
         serde_json::Value::String(s) => match s.as_str() {
-            "half" => display_size / 2,
-            "third" => display_size / 3,
-            "max" => display_size,
-            _ => display_size, // デフォルト
+            "half" => Ok(display_size / 2),
+            "third" => Ok(display_size / 3),
+            "max" => Ok(display_size),
+            _ => Err(AppConfigError {
+                message: format!("無効なサイズ値: '{}' (half, third, max を指定)", s),
+            }),
         },
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                i as i32
+                if i <= 0 {
+                    Err(AppConfigError {
+                        message: "サイズは正の値である必要があります".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
             } else {
-                display_size
+                Err(AppConfigError {
+                    message: "サイズは整数である必要があります".to_string(),
+                })
             }
         }
-        _ => display_size, // デフォルト
+        _ => Err(AppConfigError {
+            message: "サイズは文字列または数値である必要があります".to_string(),
+        }),
     }
 }
 
@@ -559,7 +580,7 @@ fn calculate_x_for_validation(
     match value {
         serde_json::Value::String(s) => match s.as_str() {
             "left" => Ok(0),
-            "right" => Ok((display_width - window_width).max(0)),
+            "right" => Ok(display_width - window_width),
             _ => Err(AppConfigError {
                 message: format!("無効な x 値: '{}'", s),
             }),
@@ -593,8 +614,8 @@ fn calculate_y_for_validation(
 ) -> Result<i32, AppConfigError> {
     match value {
         serde_json::Value::String(s) => match s.as_str() {
-            "top" => Ok(25), // メニューバーの高さ
-            "bottom" => Ok((display_height - window_height).max(0)),
+            "top" => Ok(25), // メニューバーの高さは25pxと想定
+            "bottom" => Ok(display_height - window_height),
             _ => Err(AppConfigError {
                 message: format!("無効な y 値: '{}'", s),
             }),
@@ -699,7 +720,7 @@ fn parse_y_value(
 ) -> Result<i32, AppConfigError> {
     match value {
         serde_json::Value::String(s) => match s.as_str() {
-            "top" => Ok(25), // Menu bar height is assumed to be 25px
+            "top" => Ok(25), // メニューバーの高さは25pxと想定
             "bottom" => Ok(display_height - window_height),
             _ => Err(AppConfigError {
                 message: format!("無効な y 値: '{}' (top, bottom を指定)", s),

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,13 +133,24 @@ pub fn get_config_dir() -> Result<PathBuf, AppConfigError> {
         })
 }
 
+/// 設定ファイルの検証結果として、ディスプレイ外の座標やサイズが大きすぎる場合などの警告を格納する構造体
+#[derive(Debug, Clone)]
+pub struct ValidationWarning {
+    /// ディスプレイ名
+    pub display_name: String,
+    /// アプリケーション名
+    pub app_name: String,
+    /// 問題の説明
+    pub issue: String,
+}
+
 #[allow(dead_code)]
 pub fn parse_config_from_json(json_str: &str) -> Result<AppConfig, AppConfigError> {
     let config: AppConfig = serde_json::from_str(json_str).map_err(|e| AppConfigError {
         message: format!("JSON パースエラー: {}", e),
     })?;
 
-    validate_config(&config)?;
+    validate_config_syntax(&config)?;
     Ok(config)
 }
 
@@ -186,8 +197,10 @@ pub fn save_config_file(config: &AppConfig, path: &PathBuf) -> Result<(), AppCon
     Ok(())
 }
 
+/// 設定ファイルの構文チェックのみを実行する
+/// バージョンチェック、構造の妥当性、パターン値の検証などを行う
 #[allow(dead_code)]
-fn validate_config(config: &AppConfig) -> Result<(), AppConfigError> {
+pub fn validate_config_syntax(config: &AppConfig) -> Result<(), AppConfigError> {
     // バージョンチェック
     if config.version != SUPPORTED_VERSION {
         return Err(AppConfigError {
@@ -355,6 +368,256 @@ fn validate_notification_config(notification: &NotificationConfig) -> Result<(),
     }
 
     Ok(())
+}
+
+/// ウィンドウの座標・サイズがディスプレイの境界内に収まっているかを検証
+/// ディスプレイ外の座標や、画面より大きいサイズが設定されている場合は警告を返す
+#[allow(dead_code)]
+fn validate_display_bounds(
+    window: &AppWindowConfig,
+    display_info: &crate::applescript::DisplayInfo,
+    display_name: &str,
+) -> Option<ValidationWarning> {
+    // 座標をピクセル単位で計算してチェック
+    if let Some(ref position) = window.position {
+        // サイズを計算（デフォルトはディスプレイサイズ）
+        let window_width = if let Some(ref size) = window.size {
+            calculate_size_for_validation(&size.width, display_info.width)
+        } else {
+            display_info.width
+        };
+
+        let window_height = if let Some(ref size) = window.size {
+            calculate_size_for_validation(&size.height, display_info.height)
+        } else {
+            display_info.height
+        };
+
+        // 座標を計算
+        let (x, y) = match calculate_position_for_validation(
+            position,
+            display_info.width,
+            display_info.height,
+            window_width,
+            window_height,
+        ) {
+            Ok((x, y)) => (x, y),
+            Err(_) => return None, // エラーは構文チェックで処理済み
+        };
+
+        // ウィンドウの右端がディスプレイを超えるかチェック
+        if x + window_width > display_info.width {
+            return Some(ValidationWarning {
+                display_name: display_name.to_string(),
+                app_name: window.app.clone(),
+                issue: format!(
+                    "ウィンドウの右端 ({}) がディスプレイの幅 ({}) を超えています",
+                    x + window_width,
+                    display_info.width
+                ),
+            });
+        }
+
+        // ウィンドウの下端がディスプレイを超えるかチェック
+        if y + window_height > display_info.height {
+            return Some(ValidationWarning {
+                display_name: display_name.to_string(),
+                app_name: window.app.clone(),
+                issue: format!(
+                    "ウィンドウの下端 ({}) がディスプレイの高さ ({}) を超えています",
+                    y + window_height,
+                    display_info.height
+                ),
+            });
+        }
+    }
+
+    None
+}
+
+/// ディスプレイ名が実際に接続されているかを検証
+#[allow(dead_code)]
+fn validate_display_exists(
+    display_name: &str,
+    connected_displays: &[crate::applescript::DisplayInfo],
+) -> bool {
+    connected_displays
+        .iter()
+        .any(|display| display.name == display_name)
+}
+
+/// 境界値チェックを実行（ディスプレイ情報が必要）
+/// 警告リストを返す（エラーではなく警告）
+#[allow(dead_code)]
+pub fn validate_config_bounds(
+    config: &AppConfig,
+    connected_displays: &[crate::applescript::DisplayInfo],
+) -> Result<Vec<ValidationWarning>, AppConfigError> {
+    let mut warnings = Vec::new();
+
+    // 最初のレイアウトをチェック
+    let layout = config.layouts.first().ok_or_else(|| AppConfigError {
+        message: "レイアウトが定義されていません".to_string(),
+    })?;
+
+    for display_config in &layout.displays {
+        // ディスプレイが接続されているかチェック
+        if !validate_display_exists(&display_config.name, connected_displays) {
+            for window in &display_config.windows {
+                warnings.push(ValidationWarning {
+                    display_name: display_config.name.clone(),
+                    app_name: window.app.clone(),
+                    issue: format!(
+                        "ディスプレイ '{}' が接続されていません",
+                        display_config.name
+                    ),
+                });
+            }
+            continue;
+        }
+
+        // ディスプレイ情報を取得
+        if let Some(display_info) = connected_displays
+            .iter()
+            .find(|d| d.name == display_config.name)
+        {
+            for window in &display_config.windows {
+                if let Some(warning) =
+                    validate_display_bounds(window, display_info, &display_config.name)
+                {
+                    warnings.push(warning);
+                }
+            }
+        }
+    }
+
+    Ok(warnings)
+}
+
+/// 構文チェックと境界値チェックの両方を実行
+/// connected_displays が指定されていない場合は構文チェックのみを実行
+#[allow(dead_code)]
+pub fn validate_config(
+    config: &AppConfig,
+    connected_displays: Option<&[crate::applescript::DisplayInfo]>,
+) -> Result<Vec<ValidationWarning>, AppConfigError> {
+    // 構文チェックを実行
+    validate_config_syntax(config)?;
+
+    // 境界値チェックを実行
+    if let Some(displays) = connected_displays {
+        validate_config_bounds(config, displays)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+// =============================================================================
+// Helper Functions for Validation
+// =============================================================================
+
+/// サイズ値をピクセル単位で計算（検証用）
+fn calculate_size_for_validation(value: &serde_json::Value, display_size: i32) -> i32 {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "half" => display_size / 2,
+            "third" => display_size / 3,
+            "max" => display_size,
+            _ => display_size, // デフォルト
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                i as i32
+            } else {
+                display_size
+            }
+        }
+        _ => display_size, // デフォルト
+    }
+}
+
+/// 座標値をピクセル単位で計算（検証用）
+fn calculate_position_for_validation(
+    position: &Position,
+    display_width: i32,
+    display_height: i32,
+    window_width: i32,
+    window_height: i32,
+) -> Result<(i32, i32), AppConfigError> {
+    let x = calculate_x_for_validation(&position.x, display_width, window_width)?;
+    let y = calculate_y_for_validation(&position.y, display_height, window_height)?;
+
+    Ok((x, y))
+}
+
+/// X座標を計算（検証用）
+fn calculate_x_for_validation(
+    value: &serde_json::Value,
+    display_width: i32,
+    window_width: i32,
+) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "left" => Ok(0),
+            "right" => Ok((display_width - window_width).max(0)),
+            _ => Err(AppConfigError {
+                message: format!("無効な x 値: '{}'", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Err(AppConfigError {
+                        message: "x が負です".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "x は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "x は文字列または数値である必要があります".to_string(),
+        }),
+    }
+}
+
+/// Y座標を計算（検証用）
+fn calculate_y_for_validation(
+    value: &serde_json::Value,
+    display_height: i32,
+    window_height: i32,
+) -> Result<i32, AppConfigError> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "top" => Ok(25), // メニューバーの高さ
+            "bottom" => Ok((display_height - window_height).max(0)),
+            _ => Err(AppConfigError {
+                message: format!("無効な y 値: '{}'", s),
+            }),
+        },
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i < 0 {
+                    Err(AppConfigError {
+                        message: "y が負です".to_string(),
+                    })
+                } else {
+                    Ok(i as i32)
+                }
+            } else {
+                Err(AppConfigError {
+                    message: "y は整数である必要があります".to_string(),
+                })
+            }
+        }
+        _ => Err(AppConfigError {
+            message: "y は文字列または数値である必要があります".to_string(),
+        }),
+    }
 }
 
 // =============================================================================

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,6 @@
 use crate::applescript::{self, DisplayInfo};
 use crate::config::{AppConfig, AppWindowConfig};
+use std::collections::HashSet;
 use std::thread;
 use std::time::Duration;
 
@@ -63,7 +64,7 @@ pub fn load_layout(config: &AppConfig, timeout_ms: u64) -> Result<LoadResult, Lo
             "ディスプレイ '{}' のアプリ '{}': {}",
             warning.display_name,
             warning.app_name,
-            warning.issue
+            warning.message
         );
     }
 
@@ -74,16 +75,22 @@ pub fn load_layout(config: &AppConfig, timeout_ms: u64) -> Result<LoadResult, Lo
 
     log::info!("レイアウトを適用します");
 
-    // 3. 成功・失敗カウンタ
+    // 3. ワーニング対象をHashSetに変換（O(1)検索用）
+    let warning_set: HashSet<(String, String)> = warnings
+        .iter()
+        .map(|w| (w.display_name.clone(), w.app_name.clone()))
+        .collect();
+
+    // 4. 成功・失敗カウンタ
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut failed_apps: Vec<String> = Vec::new();
 
-    // 4. 各ディスプレイの設定を処理
+    // 5. 各ディスプレイの設定を処理
     for display_config in &layout.displays {
         log::debug!("ディスプレイ '{}' の処理を開始", display_config.name);
 
-        // 4.1 ディスプレイ情報を取得
+        // 5.1 ディスプレイ情報を取得
         let display_info = match applescript::get_display_info(Some(&display_config.name)) {
             Ok(info) => info,
             Err(e) => {
@@ -103,17 +110,16 @@ pub fn load_layout(config: &AppConfig, timeout_ms: u64) -> Result<LoadResult, Lo
             display_info.height
         );
 
-        // 4.2 各ウィンドウの設定を処理
+        // 5.2 各ウィンドウの設定を処理
         for window_config in &display_config.windows {
             log::debug!("アプリ '{}' の処理を開始", window_config.app);
 
-            // ウィンドウがワーニング対象かチェック
-            let has_warning = warnings
-                .iter()
-                .any(|w| w.display_name == display_config.name && w.app_name == window_config.app);
+            // ウィンドウがワーニング対象かチェック（O(1)で検索）
+            let has_warning =
+                warning_set.contains(&(display_config.name.clone(), window_config.app.clone()));
 
             if has_warning {
-                log::info!(
+                log::warn!(
                     "アプリ '{}' は検証エラーのためスキップされます",
                     window_config.app
                 );
@@ -231,17 +237,28 @@ fn process_window(
 
     // 4. サイズを計算
     let (size_opt, position_opt) = if let Some(ref size) = window_config.size {
-        let width = calculate_width(size, display_info.width)?;
-        let height = calculate_height(size, display_info.height)?;
+        let size_value = serde_json::to_value(size)
+            .map_err(|e| format!("サイズ情報のシリアライズに失敗しました: {}", e))?;
+        let (width, height) = crate::config::parse_size_value(
+            &size_value,
+            display_info.width,
+            display_info.height,
+            "size",
+        )
+        .map_err(|e| format!("サイズ計算失敗: {}", e))?;
 
         let position = if let Some(ref position) = window_config.position {
-            let (x, y) = calculate_position(
-                position,
+            let position_value = serde_json::to_value(position)
+                .map_err(|e| format!("位置情報のシリアライズに失敗しました: {}", e))?;
+            let (x, y) = crate::config::parse_position_value(
+                &position_value,
                 display_info.width,
                 display_info.height,
                 width,
                 height,
-            )?;
+                "position",
+            )
+            .map_err(|e| format!("位置計算失敗: {}", e))?;
             // ディスプレイの origin 座標を加算して、全体座標系に変換
             Some((x + display_info.origin_x, y + display_info.origin_y))
         } else {
@@ -251,13 +268,17 @@ fn process_window(
         (Some((width, height)), position)
     } else if let Some(ref position) = window_config.position {
         // サイズ指定なしの場合はディスプレイサイズを使用
-        let (x, y) = calculate_position(
-            position,
+        let position_value = serde_json::to_value(position)
+            .map_err(|e| format!("位置情報のシリアライズに失敗しました: {}", e))?;
+        let (x, y) = crate::config::parse_position_value(
+            &position_value,
             display_info.width,
             display_info.height,
             display_info.width,
             display_info.height,
-        )?;
+            "position",
+        )
+        .map_err(|e| format!("位置計算失敗: {}", e))?;
         // ディスプレイの origin 座標を加算して、全体座標系に変換
         (
             None,
@@ -311,108 +332,4 @@ fn process_window(
     })?;
 
     Ok(())
-}
-
-/// 幅を計算する
-fn calculate_width(size: &crate::config::Size, display_width: i32) -> Result<i32, String> {
-    use serde_json::Value;
-
-    let width_value = match &size.width {
-        v if *v == Value::Null => Value::Null,
-        v => v.clone(),
-    };
-
-    if width_value == Value::Null {
-        return Ok(display_width);
-    }
-
-    // width 値を直接パース
-    match &width_value {
-        Value::String(s) => match s.as_str() {
-            "half" => Ok(display_width / 2),
-            "third" => Ok(display_width / 3),
-            "max" => Ok(display_width),
-            _ => Err(format!(
-                "無効な width 値: '{}' (half, third, max を指定)",
-                s
-            )),
-        },
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i <= 0 {
-                    Err("幅は正の値である必要があります".to_string())
-                } else {
-                    Ok(i as i32)
-                }
-            } else {
-                Err("幅は整数である必要があります".to_string())
-            }
-        }
-        _ => Err("幅は文字列または数値である必要があります".to_string()),
-    }
-}
-
-/// 高さを計算する
-fn calculate_height(size: &crate::config::Size, display_height: i32) -> Result<i32, String> {
-    use serde_json::Value;
-
-    let height_value = match &size.height {
-        v if *v == Value::Null => Value::Null,
-        v => v.clone(),
-    };
-
-    if height_value == Value::Null {
-        return Ok(display_height);
-    }
-
-    // height 値を直接パース
-    match &height_value {
-        Value::String(s) => match s.as_str() {
-            "half" => Ok(display_height / 2),
-            "third" => Ok(display_height / 3),
-            "max" => Ok(display_height),
-            _ => Err(format!(
-                "無効な height 値: '{}' (half, third, max を指定)",
-                s
-            )),
-        },
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                if i <= 0 {
-                    Err("高さは正の値である必要があります".to_string())
-                } else {
-                    Ok(i as i32)
-                }
-            } else {
-                Err("高さは整数である必要があります".to_string())
-            }
-        }
-        _ => Err("高さは文字列または数値である必要があります".to_string()),
-    }
-}
-
-/// 位置を計算する
-fn calculate_position(
-    position: &crate::config::Position,
-    display_width: i32,
-    display_height: i32,
-    window_width: i32,
-    window_height: i32,
-) -> Result<(i32, i32), String> {
-    use crate::config::parse_position_value;
-
-    let position_value = serde_json::to_value(position)
-        .map_err(|e| format!("位置情報のシリアライズに失敗しました: {}", e))?;
-
-    match parse_position_value(
-        &position_value,
-        display_width,
-        display_height,
-        window_width,
-        window_height,
-        "position",
-    ) {
-        Ok((x, y)) => Ok((x, y)),
-        Err(e) => Err(format!("位置計算失敗: {}", e)),
-    }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -43,13 +43,31 @@ impl std::error::Error for LoadError {}
 /// * `Err(LoadError)` - 全体失敗（致命的エラー）
 pub fn load_layout(config: &AppConfig, timeout_ms: u64) -> Result<LoadResult, LoadError> {
     // 1. 接続されているディスプレイ情報を取得
-    let _connected_displays = applescript::get_all_connected_displays().map_err(|e| LoadError {
+    let connected_displays = applescript::get_all_connected_displays().map_err(|e| LoadError {
         message: format!("ディスプレイ情報の取得に失敗しました: {}", e),
     })?;
 
     log::debug!("接続ディスプレイ情報を取得しました");
 
-    // 2. 最初のレイアウトを使用
+    // 2. 設定ファイルの境界値チェックを実行
+    let warnings =
+        crate::config::validate_config_bounds(config, &connected_displays).map_err(|e| {
+            LoadError {
+                message: format!("設定ファイルの検証に失敗しました: {}", e),
+            }
+        })?;
+
+    // ワーニングをログ出力
+    for warning in &warnings {
+        log::warn!(
+            "ディスプレイ '{}' のアプリ '{}': {}",
+            warning.display_name,
+            warning.app_name,
+            warning.issue
+        );
+    }
+
+    // 3. 最初のレイアウトを使用
     let layout = config.layouts.first().ok_or_else(|| LoadError {
         message: "レイアウトが定義されていません".to_string(),
     })?;
@@ -88,6 +106,23 @@ pub fn load_layout(config: &AppConfig, timeout_ms: u64) -> Result<LoadResult, Lo
         // 4.2 各ウィンドウの設定を処理
         for window_config in &display_config.windows {
             log::debug!("アプリ '{}' の処理を開始", window_config.app);
+
+            // ウィンドウがワーニング対象かチェック
+            let has_warning = warnings
+                .iter()
+                .any(|w| w.display_name == display_config.name && w.app_name == window_config.app);
+
+            if has_warning {
+                log::info!(
+                    "アプリ '{}' は検証エラーのためスキップされます",
+                    window_config.app
+                );
+                failure_count += 1;
+                if !failed_apps.contains(&window_config.app) {
+                    failed_apps.push(window_config.app.clone());
+                }
+                continue;
+            }
 
             match process_window(window_config, &display_info, timeout_ms) {
                 Ok(()) => {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -772,7 +772,7 @@ fn test_validate_display_bounds_position_out_of_display() {
     assert!(result.is_ok());
     let warnings = result.unwrap();
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].issue.contains("ウィンドウの右端"));
+    assert!(warnings[0].message.contains("ウィンドウの右端"));
     assert_eq!(warnings[0].app_name, "Google Chrome");
 }
 
@@ -818,7 +818,7 @@ fn test_validate_display_bounds_size_larger_than_display() {
     assert!(result.is_ok());
     let warnings = result.unwrap();
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].issue.contains("ウィンドウの下端"));
+    assert!(warnings[0].message.contains("ウィンドウの下端"));
     assert_eq!(warnings[0].app_name, "Safari");
 }
 
@@ -905,8 +905,8 @@ fn test_validate_display_exists_ng() {
     assert!(result.is_ok());
     let warnings = result.unwrap();
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].issue.contains("ディスプレイ '"));
-    assert!(warnings[0].issue.contains("が接続されていません"));
+    assert!(warnings[0].message.contains("ディスプレイ '"));
+    assert!(warnings[0].message.contains("が接続されていません"));
     assert_eq!(warnings[0].display_name, "Nonexistent Display");
 }
 
@@ -965,8 +965,8 @@ fn test_validate_config_bounds_all_warnings() {
     assert!(result.is_ok());
     let warnings = result.unwrap();
     assert_eq!(warnings.len(), 2); // 座標外 + ディスプレイなし
-    assert!(warnings[0].issue.contains("ウィンドウの右端"));
-    assert!(warnings[1].issue.contains("ディスプレイ"));
+    assert!(warnings[0].message.contains("ウィンドウの右端"));
+    assert!(warnings[1].message.contains("ディスプレイ"));
 }
 
 /// validate_config() が構文チェックと境界値チェックを組み合わせることを確認
@@ -1011,5 +1011,5 @@ fn test_validate_config_syntax_and_bounds() {
     assert!(result.is_ok());
     let warnings = result.unwrap();
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].issue.contains("右端"));
+    assert!(warnings[0].message.contains("右端"));
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,4 +1,9 @@
-use apptidying::config::{parse_position_value, parse_size_value};
+use apptidying::applescript::DisplayInfo;
+use apptidying::config::{
+    parse_position_value, parse_size_value, validate_config, validate_config_bounds,
+    validate_config_syntax, AppConfig, AppWindowConfig, DisplayConfig, LayoutConfig, Position,
+    Size,
+};
 use serde_json::json;
 
 // =============================================================================
@@ -659,4 +664,352 @@ fn test_parse_size_odd_display_dimensions() {
     let (width, height) = result.unwrap();
     assert_eq!(width, 1921 / 2); // 整数除算
     assert_eq!(height, 1081 / 3);
+}
+
+// =============================================================================
+// Configuration Validation Tests (Phase 3-4)
+// =============================================================================
+
+/// validate_config_syntax() がバージョン確認を正確に実行することを検証
+#[test]
+fn test_validate_config_syntax_version_ok() {
+    // 目的: サポートされているバージョン (1.0) の設定が成功することを確認
+    // 検証項目: バージョン 1.0 がサポートされていることを確認
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Built-in".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Google Chrome".to_string(),
+                    title: None,
+                    position: None,
+                    size: None,
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    // 検証: バージョンチェックが成功する
+    let result = validate_config_syntax(&config);
+    assert!(result.is_ok());
+}
+
+/// validate_config_syntax() がサポートされていないバージョンでエラーを返すことを確認
+#[test]
+fn test_validate_config_syntax_version_ng() {
+    // 目的: サポートされていないバージョン (2.0) の設定がエラーになることを確認
+    // 検証項目: バージョン 2.0 がエラーになる
+
+    let config = AppConfig {
+        version: "2.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Built-in".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Google Chrome".to_string(),
+                    title: None,
+                    position: None,
+                    size: None,
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    // 検証: バージョンチェックがエラーになる
+    let result = validate_config_syntax(&config);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .message
+        .contains("サポートされていないバージョン"));
+}
+
+/// validate_config_bounds() がディスプレイ外の座標を検出することを確認
+#[test]
+fn test_validate_display_bounds_position_out_of_display() {
+    // 目的: ウィンドウの右端がディスプレイを超える場合にワーニングが発生することを確認
+    // 検証項目: 座標とサイズの組み合わせでディスプレイ外判定が正確に動作
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Built-in".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Google Chrome".to_string(),
+                    title: None,
+                    position: Some(Position {
+                        x: json!(1800), // 1800 から始まる
+                        y: json!("top"),
+                    }),
+                    size: Some(Size {
+                        width: json!(500), // 500 幅（1800 + 500 = 2300 > 1920）
+                        height: json!("max"),
+                    }),
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![DisplayInfo {
+        name: "Built-in".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    }];
+
+    // 検証: 座標がディスプレイ外の場合、ワーニングが返される
+    let result = validate_config_bounds(&config, &connected_displays);
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].issue.contains("ウィンドウの右端"));
+    assert_eq!(warnings[0].app_name, "Google Chrome");
+}
+
+/// validate_config_bounds() が画面より大きいサイズを検出することを確認
+#[test]
+fn test_validate_display_bounds_size_larger_than_display() {
+    // 目的: ウィンドウの高さがディスプレイを超える場合にワーニングが発生することを確認
+    // 検証項目: サイズがディスプレイより大きい場合の検出
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Built-in".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Safari".to_string(),
+                    title: None,
+                    position: Some(Position {
+                        x: json!("left"),
+                        y: json!("top"),
+                    }),
+                    size: Some(Size {
+                        width: json!(800),
+                        height: json!(1500), // 1500 > 1080（ディスプレイ高）
+                    }),
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![DisplayInfo {
+        name: "Built-in".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    }];
+
+    // 検証: サイズがディスプレイを超える場合、ワーニングが返される
+    let result = validate_config_bounds(&config, &connected_displays);
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].issue.contains("ウィンドウの下端"));
+    assert_eq!(warnings[0].app_name, "Safari");
+}
+
+/// validate_config_bounds() が接続されているディスプレイを正確に判定することを確認
+#[test]
+fn test_validate_display_exists_ok() {
+    // 目的: 接続されているディスプレイ名が正確に判定されることを確認
+    // 検証項目: 複数のディスプレイが接続されている場合、正しいものを特定
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "External Display".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Xcode".to_string(),
+                    title: None,
+                    position: None,
+                    size: None,
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![
+        DisplayInfo {
+            name: "Built-in".to_string(),
+            width: 1440,
+            height: 900,
+            origin_x: 0,
+            origin_y: 0,
+        },
+        DisplayInfo {
+            name: "External Display".to_string(),
+            width: 2560,
+            height: 1440,
+            origin_x: 1440,
+            origin_y: 0,
+        },
+    ];
+
+    // 検証: 接続されているディスプレイに対してワーニングが発生しない
+    let result = validate_config_bounds(&config, &connected_displays);
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert!(warnings.is_empty());
+}
+
+/// validate_config_bounds() が接続されていないディスプレイを検出することを確認
+#[test]
+fn test_validate_display_exists_ng() {
+    // 目的: 接続されていないディスプレイ名でワーニングが発生することを確認
+    // 検証項目: 存在しないディスプレイに対してワーニングが返される
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Nonexistent Display".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "Terminal".to_string(),
+                    title: None,
+                    position: None,
+                    size: None,
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![DisplayInfo {
+        name: "Built-in".to_string(),
+        width: 1440,
+        height: 900,
+        origin_x: 0,
+        origin_y: 0,
+    }];
+
+    // 検証: 接続されていないディスプレイに対してワーニングが発生する
+    let result = validate_config_bounds(&config, &connected_displays);
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].issue.contains("ディスプレイ '"));
+    assert!(warnings[0].issue.contains("が接続されていません"));
+    assert_eq!(warnings[0].display_name, "Nonexistent Display");
+}
+
+/// validate_config_bounds() が複数の警告を正確に返すことを確認
+#[test]
+fn test_validate_config_bounds_all_warnings() {
+    // 目的: 複数の問題（座標外、サイズ大きい、ディスプレイなし）が同時に検出されることを確認
+    // 検証項目: 複数の異なるウィンドウ設定で複数の警告が返される
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![
+                // ディスプレイ 1: 座標外
+                DisplayConfig {
+                    name: "Built-in".to_string(),
+                    windows: vec![AppWindowConfig {
+                        app: "Chrome".to_string(),
+                        title: None,
+                        position: Some(Position {
+                            x: json!(1900),
+                            y: json!("top"),
+                        }),
+                        size: Some(Size {
+                            width: json!(500),
+                            height: json!(600),
+                        }),
+                    }],
+                },
+                // ディスプレイ 2: 接続されていない
+                DisplayConfig {
+                    name: "Disconnected".to_string(),
+                    windows: vec![AppWindowConfig {
+                        app: "Safari".to_string(),
+                        title: None,
+                        position: None,
+                        size: None,
+                    }],
+                },
+            ],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![DisplayInfo {
+        name: "Built-in".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    }];
+
+    // 検証: 複数の警告が返される
+    let result = validate_config_bounds(&config, &connected_displays);
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert_eq!(warnings.len(), 2); // 座標外 + ディスプレイなし
+    assert!(warnings[0].issue.contains("ウィンドウの右端"));
+    assert!(warnings[1].issue.contains("ディスプレイ"));
+}
+
+/// validate_config() が構文チェックと境界値チェックを組み合わせることを確認
+#[test]
+fn test_validate_config_syntax_and_bounds() {
+    // 目的: ラッパー関数が構文チェックと境界値チェックを正確に実行することを確認
+    // 検証項目: バージョンエラー（構文）と座標外エラー（境界値）の両方が検出される
+
+    let config = AppConfig {
+        version: "1.0".to_string(),
+        layouts: vec![LayoutConfig {
+            displays: vec![DisplayConfig {
+                name: "Built-in".to_string(),
+                windows: vec![AppWindowConfig {
+                    app: "App".to_string(),
+                    title: None,
+                    position: Some(Position {
+                        x: json!(2000),
+                        y: json!("top"),
+                    }),
+                    size: Some(Size {
+                        width: json!(500),
+                        height: json!(600),
+                    }),
+                }],
+            }],
+        }],
+        notification: None,
+        timeout: None,
+    };
+
+    let connected_displays = vec![DisplayInfo {
+        name: "Built-in".to_string(),
+        width: 1920,
+        height: 1080,
+        origin_x: 0,
+        origin_y: 0,
+    }];
+
+    // 検証: 構文チェックを通り、境界値警告が返される
+    let result = validate_config(&config, Some(&connected_displays));
+    assert!(result.is_ok());
+    let warnings = result.unwrap();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].issue.contains("右端"));
 }


### PR DESCRIPTION
## 概要

Issue #30 の P3-4 設定ファイル互換性・検証機能を実装しました。

設定ファイルの検証ロジックを 2 段階に分離し、構文チェック（JSON パース時）と境界値チェック（load 実行時）を実施します。

## 実装内容

### 1. ValidationWarning 構造体
ディスプレイ外の座標やサイズが大きすぎる場合などの警告を格納

### 2. 検証関数（config.rs）
- `validate_config_syntax()`：構文チェックのみ（JSON パース時に実行）
- `validate_display_bounds()`：ウィンドウ座標・サイズの検証
- `validate_display_exists()`：ディスプレイ接続確認
- `validate_config_bounds()`：境界値チェック＋警告リスト返却
- `validate_config()`：ラッパー関数

### 3. 呼び出し側の更新（loader.rs）
- `load_layout()` に境界値チェック処理を追加
- ワーニング対象のウィンドウはスキップして処理継続

### 4. テスト実装（tests/config_test.rs）
8 つの包括的なユニットテストを追加：
- バージョン検証（OK/NG）
- ディスプレイ外の座標検出
- 画面より大きいサイズ検出
- ディスプレイ接続確認
- 複数警告の同時検出
- 統合検証テスト

## テスト結果
✅ 全テスト: 397 passed; 0 failed; 115 ignored
✅ config_test: 56 passed（新規 8 個を含む）

## 成功基準
- ✅ バージョン検証が正確に動作
- ✅ 境界値チェック（座標・サイズ）が正確に動作
- ✅ ディスプレイ名検証が正確に動作
- ✅ ワーニング対象ウィンドウはスキップ
- ✅ 他のウィンドウは正常に処理

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)